### PR TITLE
chore: remove self-reference dependency from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
-    "@shareai-lab/kode-sdk": "^1.0.0-beta.9",
     "@types/node": "^20.0.0",
     "ts-node": "^10.9.0",
     "typescript": "^5.3.0"


### PR DESCRIPTION
Fixes #10

## Problem

The `package.json` contains a self-reference dependency in `devDependencies`:

``json
"devDependencies": {
  "@shareai-lab/kode-sdk": "^1.0.0-beta.9",
  ...
}
``

This causes:
- **Circular dependency** - package depends on itself
- **Version confusion** - current version is 2.7.0, but references old 1.0.0-beta.9
- **Publishing issues** - npm may reject packages with self-references

## Changes

- Remove `@shareai-lab/kode-sdk` from `devDependencies`

## Checklist

- [x] Code builds successfully (`npm run build`)
- [ ] Tests pass (`npm test`)
- [ ] Documentation updated (if needed)