### PR TITLE
feat: add OpenRouter provider support (consolidates #7, #8, #9)

### DIFF
--- a/examples/05-openrouter-complete.ts
+++ b/examples/05-openrouter-complete.ts
@@ -1,0 +1,45 @@
+import './shared/load-env';
+
+import { OpenRouterProvider, Message } from '../src';
+
+async function main() {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  const modelId = process.env.OPENROUTER_MODEL_ID;
+  const baseUrl = process.env.OPENROUTER_BASE_URL;
+
+  if (!apiKey) {
+    throw new Error('Missing OPENROUTER_API_KEY');
+  }
+  if (!modelId) {
+    throw new Error('Missing OPENROUTER_MODEL_ID (e.g. openai/gpt-4.1-mini, anthropic/claude-3.5-sonnet)');
+  }
+
+  const provider = new OpenRouterProvider(apiKey, modelId, baseUrl);
+
+  const messages: Message[] = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Hello! Summarize the core benefits of "event-driven agent runtime" in three sentences.' }],
+    },
+  ];
+
+  const resp = await provider.complete(messages, {
+    system: 'You are a helpful engineer. Keep answers short.',
+    maxTokens: 400,
+    temperature: 0.2,
+  });
+
+  const text = resp.content
+    .map((b) => (b.type === 'text' ? b.text : `[${b.type}]`))
+    .join('');
+
+  console.log(text);
+  if (resp.usage) {
+    console.log(`\n--- usage: in=${resp.usage.input_tokens} out=${resp.usage.output_tokens} ---`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/06-openrouter-stream.ts
+++ b/examples/06-openrouter-stream.ts
@@ -1,0 +1,73 @@
+import './shared/load-env';
+
+import { OpenRouterProvider, Message, ModelStreamChunk } from '../src';
+
+function chunkToDebugString(chunk: ModelStreamChunk): string {
+  if (chunk.type === 'content_block_start') {
+    const t = (chunk.content_block as any)?.type;
+    if (t === 'tool_use') {
+      return `\n[tool_use:start] ${(chunk.content_block as any).name} id=${(chunk.content_block as any).id}\n`;
+    }
+    if (t === 'text') {
+      return `\n[text:start]\n`;
+    }
+  }
+
+  if (chunk.type === 'content_block_delta') {
+    if (chunk.delta?.type === 'text_delta') {
+      return chunk.delta.text ?? '';
+    }
+    if (chunk.delta?.type === 'input_json_delta') {
+      return chunk.delta.partial_json ? `[tool_args_delta] ${chunk.delta.partial_json}` : '';
+    }
+  }
+
+  if (chunk.type === 'content_block_stop') {
+    return `\n[block:stop]\n`;
+  }
+
+  if (chunk.type === 'message_stop') {
+    return `\n[message:stop]\n`;
+  }
+
+  return '';
+}
+
+async function main() {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  const modelId = process.env.OPENROUTER_MODEL_ID;
+  const baseUrl = process.env.OPENROUTER_BASE_URL;
+
+  if (!apiKey) throw new Error('Missing OPENROUTER_API_KEY');
+  if (!modelId) throw new Error('Missing OPENROUTER_MODEL_ID (e.g. openai/gpt-4.1-mini)');
+
+  const provider = new OpenRouterProvider(apiKey, modelId, baseUrl);
+
+  const messages: Message[] = [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Explain what a streaming response is in 5 lines or less, and give a brief example.',
+        },
+      ],
+    },
+  ];
+
+  const stream = provider.stream(messages, {
+    system: 'You are a helpful engineer. Keep answers short.',
+    maxTokens: 300,
+    temperature: 0.2,
+  });
+
+  for await (const chunk of stream) {
+    const s = chunkToDebugString(chunk);
+    if (s) process.stdout.write(s);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/07-openrouter-agent.ts
+++ b/examples/07-openrouter-agent.ts
@@ -1,0 +1,77 @@
+import './shared/load-env';
+
+import {
+  Agent,
+  AgentDependencies,
+  AgentTemplateRegistry,
+  JSONStore,
+  SandboxFactory,
+  ToolRegistry,
+} from '../src';
+
+function createOpenRouterRuntime(setup: (ctx: { templates: AgentTemplateRegistry; tools: ToolRegistry; sandboxFactory: SandboxFactory }) => void): AgentDependencies {
+  const store = new JSONStore('./.kode');
+  const templates = new AgentTemplateRegistry();
+  const tools = new ToolRegistry();
+  const sandboxFactory = new SandboxFactory();
+
+  setup({ templates, tools, sandboxFactory });
+
+  return {
+    store,
+    templateRegistry: templates,
+    sandboxFactory,
+    toolRegistry: tools,
+  };
+}
+
+async function main() {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  const modelId = process.env.OPENROUTER_MODEL_ID;
+  const baseUrl = process.env.OPENROUTER_BASE_URL;
+
+  if (!apiKey) throw new Error('Missing OPENROUTER_API_KEY');
+  if (!modelId) throw new Error('Missing OPENROUTER_MODEL_ID (e.g. openai/gpt-4.1-mini)');
+
+  const deps = createOpenRouterRuntime(({ templates }) => {
+    templates.register({
+      id: 'openrouter-hello',
+      systemPrompt: 'You are a helpful engineer. Keep answers short.',
+      tools: [],
+      runtime: {},
+    });
+  });
+
+  const agent = await Agent.create(
+    {
+      templateId: 'openrouter-hello',
+      sandbox: { kind: 'local', workDir: './workspace', enforceBoundary: true },
+      modelConfig: {
+        provider: 'openrouter',
+        apiKey,
+        model: modelId,
+        baseUrl,
+      },
+    },
+    deps
+  );
+
+  (async () => {
+    for await (const envelope of agent.subscribe(['progress'])) {
+      if (envelope.event.type === 'text_chunk') {
+        process.stdout.write(envelope.event.delta);
+      }
+      if (envelope.event.type === 'done') {
+        console.log('\n--- conversation complete ---');
+        break;
+      }
+    }
+  })();
+
+  await agent.send('Hello! Explain the core capabilities of this SDK in 5 bullet points.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "example:approval": "ts-node examples/02-approval-control.ts",
     "example:room": "ts-node examples/03-room-collab.ts",
     "example:scheduler": "ts-node examples/04-scheduler-watch.ts",
-    "example:nextjs": "ts-node examples/nextjs-api-route.ts"
+    "example:nextjs": "ts-node examples/nextjs-api-route.ts",
+    "example:openrouter": "ts-node examples/05-openrouter-complete.ts",
+    "example:openrouter-stream": "ts-node examples/06-openrouter-stream.ts",
+    "example:openrouter-agent": "ts-node examples/07-openrouter-agent.ts"
   },
   "keywords": [
     "agent",

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -36,7 +36,7 @@ import { AgentTemplateRegistry, AgentTemplateDefinition, PermissionConfig, SubAg
 import { Store } from '../infra/store';
 import { Sandbox, SandboxKind } from '../infra/sandbox';
 import { SandboxFactory } from '../infra/sandbox-factory';
-import { ModelProvider, ModelConfig, AnthropicProvider } from '../infra/provider';
+import { ModelProvider, ModelConfig, AnthropicProvider, OpenRouterProvider } from '../infra/provider';
 import { ToolRegistry, ToolInstance, ToolDescriptor } from '../tools/registry';
 import { Configurable } from './config';
 import { ContextManagerOptions } from './context-manager';
@@ -1943,6 +1943,15 @@ function ensureModelFactory(factory?: ModelFactory): ModelFactory {
         throw new Error('Anthropic provider requires apiKey');
       }
       return new AnthropicProvider(config.apiKey, config.model, config.baseUrl);
+    }
+    if (config.provider === 'openrouter') {
+      if (!config.apiKey) {
+        throw new Error('OpenRouter provider requires apiKey');
+      }
+      if (!config.model) {
+        throw new Error('OpenRouter provider requires model');
+      }
+      return new OpenRouterProvider(config.apiKey, config.model, config.baseUrl);
     }
     throw new Error(`Model factory not provided for provider: ${config.provider}`);
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,8 @@ export {
   ModelResponse,
   ModelStreamChunk,
   AnthropicProvider,
+  OpenRouterProvider,
+  createModelProvider,
 } from './infra/provider';
 export { SandboxFactory } from './infra/sandbox-factory';
 

--- a/src/infra/provider.ts
+++ b/src/infra/provider.ts
@@ -1,5 +1,6 @@
 import { Message, ContentBlock } from '../core/types';
 import { Configurable } from '../core/config';
+import { AnthropicProvider, OpenRouterProvider } from './providers';
 
 export interface ModelResponse {
   role: 'assistant';
@@ -26,7 +27,7 @@ export interface ModelStreamChunk {
 }
 
 export interface ModelConfig {
-  provider: 'anthropic' | string;
+  provider: 'anthropic' | 'openrouter' | string;
   model: string;
   baseUrl?: string;
   apiKey?: string;
@@ -63,153 +64,26 @@ export interface ModelProvider extends Configurable<ModelConfig> {
 
 }
 
-export class AnthropicProvider implements ModelProvider {
-  readonly maxWindowSize = 200_000;
-  readonly maxOutputTokens = 4096;
-  readonly temperature = 0.7;
-  readonly model: string;
-
-  constructor(
-    private apiKey: string,
-    model: string = 'claude-3-5-sonnet-20241022',
-    private baseUrl: string = 'https://api.anthropic.com'
-  ) {
-    this.model = model;
-  }
-
-  async complete(
-    messages: Message[],
-    opts?: {
-      tools?: any[];
-      maxTokens?: number;
-      temperature?: number;
-      system?: string;
-      stream?: boolean;
-    }
-  ): Promise<ModelResponse> {
-    const body: any = {
-      model: this.model,
-      messages: this.formatMessages(messages),
-      max_tokens: opts?.maxTokens || 4096,
-    };
-
-    if (opts?.temperature !== undefined) body.temperature = opts.temperature;
-    if (opts?.system) body.system = opts.system;
-    if (opts?.tools && opts.tools.length > 0) body.tools = opts.tools;
-
-    const response = await fetch(`${this.baseUrl}/v1/messages`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': this.apiKey,
-        'anthropic-version': '2023-06-01',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Anthropic API error: ${response.status} ${error}`);
-    }
-
-    const data: any = await response.json();
-    return {
-      role: 'assistant',
-      content: data.content,
-      usage: data.usage,
-      stop_reason: data.stop_reason,
-    };
-  }
-
-  async *stream(
-    messages: Message[],
-    opts?: {
-      tools?: any[];
-      maxTokens?: number;
-      temperature?: number;
-      system?: string;
-    }
-  ): AsyncIterable<ModelStreamChunk> {
-    const body: any = {
-      model: this.model,
-      messages: this.formatMessages(messages),
-      max_tokens: opts?.maxTokens || 4096,
-      stream: true,
-    };
-
-    if (opts?.temperature !== undefined) body.temperature = opts.temperature;
-    if (opts?.system) body.system = opts.system;
-    if (opts?.tools && opts.tools.length > 0) body.tools = opts.tools;
-
-    const response = await fetch(`${this.baseUrl}/v1/messages`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': this.apiKey,
-        'anthropic-version': '2023-06-01',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`Anthropic API error: ${response.status} ${error}`);
-    }
-
-    const reader = response.body?.getReader();
-    if (!reader) throw new Error('No response body');
-
-    const decoder = new TextDecoder();
-    let buffer = '';
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || '';
-
-      for (const line of lines) {
-        if (!line.trim() || !line.startsWith('data: ')) continue;
-        const data = line.slice(6);
-        if (data === '[DONE]') continue;
-
-        try {
-          const event = JSON.parse(data);
-          if (event.type === 'content_block_start') {
-            yield { type: 'content_block_start', index: event.index, content_block: event.content_block };
-          } else if (event.type === 'content_block_delta') {
-            yield { type: 'content_block_delta', index: event.index, delta: event.delta };
-          } else if (event.type === 'content_block_stop') {
-            yield { type: 'content_block_stop', index: event.index };
-          } else if (event.type === 'message_delta') {
-            yield { type: 'message_delta', delta: event.delta, usage: event.usage };
-          } else if (event.type === 'message_stop') {
-            yield { type: 'message_stop' };
-          }
-        } catch (e) {
-          // Skip invalid JSON
-        }
-      }
-    }
-  }
-
-  private formatMessages(messages: Message[]): any[] {
-    return messages.map((msg) => ({
-      role: msg.role === 'system' ? 'user' : msg.role,
-      content: msg.content,
-    }));
-  }
-
-  toConfig(): ModelConfig {
-    return {
-      provider: 'anthropic',
-      model: this.model,
-      baseUrl: this.baseUrl,
-      apiKey: this.apiKey,
-      maxTokens: this.maxOutputTokens,
-      temperature: this.temperature,
-    };
+// Provider factory function
+export function createModelProvider(config: ModelConfig): ModelProvider {
+  switch (config.provider) {
+    case 'anthropic':
+      return new AnthropicProvider(
+        config.apiKey!,
+        config.model,
+        config.baseUrl
+      );
+    case 'openrouter':
+      return new OpenRouterProvider(
+        config.apiKey!,
+        config.model,
+        config.baseUrl
+      );
+    default:
+      throw new Error(`Unsupported provider: ${config.provider}`);
   }
 }
+
+// Re-export providers
+export { AnthropicProvider, OpenRouterProvider };
+

--- a/src/infra/providers/anthropic.ts
+++ b/src/infra/providers/anthropic.ts
@@ -1,0 +1,153 @@
+import { Message } from '../../core/types';
+import { ModelProvider, ModelResponse, ModelStreamChunk, ModelConfig } from '../provider';
+
+export class AnthropicProvider implements ModelProvider {
+  readonly maxWindowSize = 200_000;
+  readonly maxOutputTokens = 4096;
+  readonly temperature = 0.7;
+  readonly model: string;
+
+  constructor(
+    private apiKey: string,
+    model: string = 'claude-3-5-sonnet-20241022',
+    private baseUrl: string = 'https://api.anthropic.com'
+  ) {
+    this.model = model;
+  }
+
+  async complete(
+    messages: Message[],
+    opts?: {
+      tools?: any[];
+      maxTokens?: number;
+      temperature?: number;
+      system?: string;
+      stream?: boolean;
+    }
+  ): Promise<ModelResponse> {
+    const body: any = {
+      model: this.model,
+      messages: this.formatMessages(messages),
+      max_tokens: opts?.maxTokens || 4096,
+    };
+
+    if (opts?.temperature !== undefined) body.temperature = opts.temperature;
+    if (opts?.system) body.system = opts.system;
+    if (opts?.tools && opts.tools.length > 0) body.tools = opts.tools;
+
+    const response = await fetch(`${this.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Anthropic API error: ${response.status} ${error}`);
+    }
+
+    const data: any = await response.json();
+    return {
+      role: 'assistant',
+      content: data.content,
+      usage: data.usage,
+      stop_reason: data.stop_reason,
+    };
+  }
+
+  async *stream(
+    messages: Message[],
+    opts?: {
+      tools?: any[];
+      maxTokens?: number;
+      temperature?: number;
+      system?: string;
+    }
+  ): AsyncIterable<ModelStreamChunk> {
+    const body: any = {
+      model: this.model,
+      messages: this.formatMessages(messages),
+      max_tokens: opts?.maxTokens || 4096,
+      stream: true,
+    };
+
+    if (opts?.temperature !== undefined) body.temperature = opts.temperature;
+    if (opts?.system) body.system = opts.system;
+    if (opts?.tools && opts.tools.length > 0) body.tools = opts.tools;
+
+    const response = await fetch(`${this.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Anthropic API error: ${response.status} ${error}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('No response body');
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (!line.trim() || !line.startsWith('data: ')) continue;
+        const data = line.slice(6);
+        if (data === '[DONE]') continue;
+
+        try {
+          const event = JSON.parse(data);
+          if (event.type === 'content_block_start') {
+            yield { type: 'content_block_start', index: event.index, content_block: event.content_block };
+          } else if (event.type === 'content_block_delta') {
+            yield { type: 'content_block_delta', index: event.index, delta: event.delta };
+          } else if (event.type === 'content_block_stop') {
+            yield { type: 'content_block_stop', index: event.index };
+          } else if (event.type === 'message_delta') {
+            yield { type: 'message_delta', delta: event.delta, usage: event.usage };
+          } else if (event.type === 'message_stop') {
+            yield { type: 'message_stop' };
+          }
+        } catch {
+          // Skip invalid JSON
+        }
+      }
+    }
+  }
+
+  private formatMessages(messages: Message[]): any[] {
+    return messages.map((msg) => ({
+      role: msg.role === 'system' ? 'user' : msg.role,
+      content: msg.content,
+    }));
+  }
+
+  toConfig(): ModelConfig {
+    return {
+      provider: 'anthropic',
+      model: this.model,
+      baseUrl: this.baseUrl,
+      apiKey: this.apiKey,
+      maxTokens: this.maxOutputTokens,
+      temperature: this.temperature,
+    };
+  }
+}

--- a/src/infra/providers/index.ts
+++ b/src/infra/providers/index.ts
@@ -1,0 +1,2 @@
+export { AnthropicProvider } from './anthropic';
+export { OpenRouterProvider } from './openrouter';

--- a/src/infra/providers/openrouter.ts
+++ b/src/infra/providers/openrouter.ts
@@ -1,0 +1,472 @@
+import { Message, ContentBlock } from '../../core/types';
+import { ModelProvider, ModelResponse, ModelStreamChunk, ModelConfig } from '../provider';
+
+export class OpenRouterProvider implements ModelProvider {
+  readonly maxWindowSize = 200_000;
+  readonly maxOutputTokens = 4096;
+  readonly temperature = 0.7;
+  readonly model: string;
+
+  constructor(
+    private apiKey: string,
+    model: string,
+    private baseUrl: string = 'https://openrouter.ai/api/v1',
+  ) {
+    this.model = model;
+  }
+
+  async complete(
+    messages: Message[],
+    opts?: {
+      tools?: any[];
+      maxTokens?: number;
+      temperature?: number;
+      system?: string;
+      stream?: boolean;
+    }
+  ): Promise<ModelResponse> {
+    const body: any = {
+      model: this.model,
+      messages: toOpenAIChatMessages(messages, opts?.system),
+    };
+
+    const maxTokens = opts?.maxTokens ?? this.maxOutputTokens;
+    if (typeof maxTokens === 'number') body.max_tokens = maxTokens;
+    if (opts?.temperature !== undefined) body.temperature = opts.temperature;
+
+    const tools = toOpenAITools(opts?.tools);
+    if (tools.length > 0) {
+      body.tools = tools;
+      body.tool_choice = 'auto';
+    }
+
+    const response = await fetch(`${stripTrailingSlash(this.baseUrl)}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`OpenRouter API error: ${response.status} ${error}`);
+    }
+
+    const data: any = await response.json();
+    const msg = data?.choices?.[0]?.message;
+    const blocks = openAIMessageToContentBlocks(msg);
+
+    return {
+      role: 'assistant',
+      content: blocks,
+      usage: data?.usage
+        ? {
+            input_tokens: data.usage.prompt_tokens ?? 0,
+            output_tokens: data.usage.completion_tokens ?? 0,
+          }
+        : undefined,
+      stop_reason: data?.choices?.[0]?.finish_reason,
+    };
+  }
+
+  async *stream(
+    messages: Message[],
+    opts?: {
+      tools?: any[];
+      maxTokens?: number;
+      temperature?: number;
+      system?: string;
+    }
+  ): AsyncIterable<ModelStreamChunk> {
+    const body: any = {
+      model: this.model,
+      messages: toOpenAIChatMessages(messages, opts?.system),
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+
+    const maxTokens = opts?.maxTokens ?? this.maxOutputTokens;
+    if (typeof maxTokens === 'number') body.max_tokens = maxTokens;
+    if (opts?.temperature !== undefined) body.temperature = opts.temperature;
+
+    const tools = toOpenAITools(opts?.tools);
+    if (tools.length > 0) {
+      body.tools = tools;
+      body.tool_choice = 'auto';
+    }
+
+    // Retry logic for rate limiting (429) errors
+    const MAX_RETRIES = 3;
+    let lastError: Error | null = null;
+    let response: Response | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        response = await fetch(`${stripTrailingSlash(this.baseUrl)}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+          body: JSON.stringify(body),
+        });
+
+        if (response.ok) {
+          break;
+        }
+
+        const errorText = await response.text();
+
+        // Only retry on 429 (rate limit) errors
+        if (response.status === 429 && attempt < MAX_RETRIES - 1) {
+          const retryAfter = response.headers.get('retry-after');
+          const waitTime = retryAfter
+            ? parseInt(retryAfter, 10) * 1000
+            : Math.min(1000 * Math.pow(2, attempt), 10000);
+
+          await new Promise(resolve => setTimeout(resolve, waitTime));
+          continue;
+        }
+
+        throw new Error(`OpenRouter API error: ${response.status} ${errorText}`);
+      } catch (e) {
+        lastError = e instanceof Error ? e : new Error(String(e));
+        if (attempt === MAX_RETRIES - 1) {
+          throw lastError;
+        }
+      }
+    }
+
+    if (!response || !response.ok) {
+      throw lastError || new Error('OpenRouter API request failed');
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('No response body');
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    let textBlockIndex: number | null = null;
+    let nextContentBlockIndex = 0;
+
+    const toolIndexToContentIndex = new Map<number, number>();
+    const toolStates = new Map<
+      number,
+      {
+        started: boolean;
+        id?: string;
+        name?: string;
+        pendingArgs: string[];
+        startedIndex?: number;
+      }
+    >();
+
+    const ensureTextStarted = () => {
+      if (textBlockIndex !== null) return;
+      textBlockIndex = nextContentBlockIndex++;
+      const index = textBlockIndex;
+      const content_block: ContentBlock = { type: 'text', text: '' };
+      return { index, content_block };
+    };
+
+    const ensureToolContentIndex = (openAiToolIndex: number): number => {
+      const existing = toolIndexToContentIndex.get(openAiToolIndex);
+      if (existing !== undefined) return existing;
+      const idx = nextContentBlockIndex++;
+      toolIndexToContentIndex.set(openAiToolIndex, idx);
+      return idx;
+    };
+
+    const tryStartTool = (openAiToolIndex: number) => {
+      const state = toolStates.get(openAiToolIndex);
+      if (!state || state.started) return;
+      const name = state.name;
+      if (!name) return;
+      const id = state.id ?? `toolu_${openAiToolIndex}_${Date.now()}`;
+      state.id = id;
+      state.started = true;
+      const contentIndex = ensureToolContentIndex(openAiToolIndex);
+      state.startedIndex = contentIndex;
+      const content_block: ContentBlock = {
+        type: 'tool_use',
+        id,
+        name,
+        input: {},
+      };
+      return { contentIndex, content_block };
+    };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.trim() || !line.startsWith('data:')) continue;
+          const data = line.replace(/^data:\s*/, '');
+          if (data === '[DONE]') continue;
+
+          let event: any;
+          try {
+            event = JSON.parse(data);
+          } catch {
+            continue;
+          }
+
+          const choice = event?.choices?.[0];
+          const delta = choice?.delta;
+
+          // Text streaming
+          if (typeof delta?.content === 'string' && delta.content.length > 0) {
+            const started = ensureTextStarted();
+            if (started) {
+              yield { type: 'content_block_start', index: started.index, content_block: started.content_block };
+            }
+            yield {
+              type: 'content_block_delta',
+              index: textBlockIndex ?? 0,
+              delta: { type: 'text_delta', text: delta.content },
+            };
+          }
+
+          // Tool call streaming
+          const toolCalls = Array.isArray(delta?.tool_calls) ? delta.tool_calls : [];
+          for (const toolCall of toolCalls) {
+            const openAiToolIndex: number = typeof toolCall?.index === 'number' ? toolCall.index : 0;
+            const state = toolStates.get(openAiToolIndex) ?? {
+              started: false,
+              pendingArgs: [],
+            };
+
+            if (typeof toolCall?.id === 'string') state.id = toolCall.id;
+            if (typeof toolCall?.function?.name === 'string') state.name = toolCall.function.name;
+            if (typeof toolCall?.function?.arguments === 'string' && toolCall.function.arguments.length > 0) {
+              state.pendingArgs.push(toolCall.function.arguments);
+            }
+
+            toolStates.set(openAiToolIndex, state);
+
+            const startedTool = tryStartTool(openAiToolIndex);
+            if (startedTool) {
+              yield {
+                type: 'content_block_start',
+                index: startedTool.contentIndex,
+                content_block: startedTool.content_block,
+              };
+            }
+
+            if (state.started) {
+              const idx = state.startedIndex ?? ensureToolContentIndex(openAiToolIndex);
+              while (state.pendingArgs.length > 0) {
+                const partial_json = state.pendingArgs.shift()!;
+                yield {
+                  type: 'content_block_delta',
+                  index: idx,
+                  delta: { type: 'input_json_delta', partial_json },
+                };
+              }
+            }
+          }
+
+          // Usage (typically only appears at end when include_usage=true)
+          if (event?.usage) {
+            const inputTokens = event.usage.prompt_tokens ?? 0;
+            const outputTokens = event.usage.completion_tokens ?? 0;
+            yield {
+              type: 'message_delta',
+              delta: { type: 'text_delta', text: '' },
+              usage: { input_tokens: inputTokens, output_tokens: outputTokens } as any,
+            } as any;
+          }
+        }
+      }
+    } finally {
+      // Close any started blocks so the Agent can finalize buffers.
+      if (textBlockIndex !== null) {
+        yield { type: 'content_block_stop', index: textBlockIndex };
+      }
+      for (const [, state] of toolStates) {
+        if (state.started && typeof state.startedIndex === 'number') {
+          yield { type: 'content_block_stop', index: state.startedIndex };
+        }
+      }
+      yield { type: 'message_stop' };
+    }
+  }
+
+  toConfig(): ModelConfig {
+    return {
+      provider: 'openrouter',
+      model: this.model,
+      baseUrl: this.baseUrl,
+      apiKey: this.apiKey,
+      maxTokens: this.maxOutputTokens,
+      temperature: this.temperature,
+    };
+  }
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+type OpenAIChatMessageContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } };
+
+type OpenAIChatMessage =
+  | { role: 'system' | 'user' | 'assistant'; content: string | OpenAIChatMessageContentPart[] | null; tool_calls?: any[] }
+  | { role: 'tool'; tool_call_id: string; content: string };
+
+function blocksToText(blocks: ContentBlock[]): string {
+  return blocks
+    .filter((b) => b.type === 'text')
+    .map((b: any) => b.text)
+    .join('\n');
+}
+
+function blocksToOpenAIContent(blocks: ContentBlock[]): string | OpenAIChatMessageContentPart[] | null {
+  const parts: OpenAIChatMessageContentPart[] = [];
+  let hasImages = false;
+  let hasNonWhitespaceText = false;
+
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      parts.push({ type: 'text', text: block.text });
+      if (block.text.trim().length > 0) {
+        hasNonWhitespaceText = true;
+      }
+      continue;
+    }
+
+    if ((block as any).type === 'image_url') {
+      const imgBlock = block as any;
+      if (typeof imgBlock.image_url?.url === 'string' && imgBlock.image_url.url.length > 0) {
+        parts.push({ type: 'image_url', image_url: { url: imgBlock.image_url.url } });
+        hasImages = true;
+      }
+    }
+  }
+
+  if (!hasImages) {
+    const text = blocksToText(blocks).trim();
+    return text.length > 0 ? text : null;
+  }
+
+  if (!hasNonWhitespaceText) {
+    parts.unshift({ type: 'text', text: 'Reference image.' });
+  }
+
+  return parts;
+}
+
+function toOpenAIChatMessages(messages: Message[], systemPrompt?: string): OpenAIChatMessage[] {
+  const out: OpenAIChatMessage[] = [];
+  if (systemPrompt) {
+    out.push({ role: 'system', content: systemPrompt });
+  }
+
+  for (const msg of messages) {
+    const role = msg.role === 'system' ? 'user' : msg.role;
+    const content = blocksToOpenAIContent(msg.content);
+    const text = blocksToText(msg.content).trim();
+
+    const toolResults = msg.content.filter((b) => b.type === 'tool_result') as Array<any>;
+    const toolUses = msg.content.filter((b) => b.type === 'tool_use') as Array<any>;
+
+    if (role === 'assistant' && toolUses.length > 0) {
+      const tool_calls = toolUses.map((b) => ({
+        id: b.id,
+        type: 'function',
+        function: {
+          name: b.name,
+          arguments: JSON.stringify(b.input ?? {}),
+        },
+      }));
+
+      out.push({ role: 'assistant', content: text.length > 0 ? text : null, tool_calls });
+    } else if (content !== null) {
+      if (role === 'assistant' && Array.isArray(content)) {
+        const assistantText = content
+          .filter((p) => p.type === 'text')
+          .map((p) => p.text)
+          .join('\n')
+          .trim();
+        if (assistantText.length > 0) {
+          out.push({ role: role as any, content: assistantText });
+        }
+      } else {
+        out.push({ role: role as any, content });
+      }
+    }
+
+    if (toolResults.length > 0) {
+      for (const b of toolResults) {
+        const contentStr = typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
+        out.push({ role: 'tool', tool_call_id: b.tool_use_id, content: contentStr });
+      }
+    }
+  }
+
+  return out;
+}
+
+function toOpenAITools(tools: any[] | undefined): any[] {
+  if (!tools || tools.length === 0) return [];
+  return tools
+    .filter((t) => t && typeof t.name === 'string')
+    .map((t) => ({
+      type: 'function',
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.input_schema ?? { type: 'object', properties: {} },
+      },
+    }));
+}
+
+function openAIMessageToContentBlocks(msg: any): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+
+  if (typeof msg?.content === 'string' && msg.content.length > 0) {
+    blocks.push({ type: 'text', text: msg.content });
+  } else if (Array.isArray(msg?.content)) {
+    for (const part of msg.content as any[]) {
+      if (part?.type === 'text' && typeof part.text === 'string' && part.text.length > 0) {
+        blocks.push({ type: 'text', text: part.text });
+      }
+    }
+  }
+
+  const toolCalls = Array.isArray(msg?.tool_calls) ? msg.tool_calls : [];
+  for (const call of toolCalls) {
+    const id = typeof call?.id === 'string' ? call.id : `toolu_${Date.now()}`;
+    const name = call?.function?.name;
+    const rawArgs = call?.function?.arguments;
+    let input: any = {};
+    if (typeof rawArgs === 'string' && rawArgs.length > 0) {
+      try {
+        input = JSON.parse(rawArgs);
+      } catch {
+        input = { _raw: rawArgs };
+      }
+    }
+
+    if (typeof name === 'string' && name.length > 0) {
+      blocks.push({ type: 'tool_use', id, name, input });
+    }
+  }
+
+  if (blocks.length === 0) {
+    blocks.push({ type: 'text', text: '' });
+  }
+
+  return blocks;
+}


### PR DESCRIPTION
## Summary

This PR consolidates and improves upon PRs #7, #8, and #9 to add OpenRouter provider support to the SDK.

### Changes
- Add `src/infra/providers/` directory structure for modular provider organization
- Implement `OpenRouterProvider` with robust features:
  - OpenAI-compatible Chat Completions API
  - Tool calling support
  - Streaming response support
  - Rate limit retry logic (429 handling)
  - Automatic format conversion (OpenAI <-> Anthropic)
- Add `createModelProvider` factory function for easy provider instantiation
- Update `ensureModelFactory` to support 'openrouter' provider
- Export `OpenRouterProvider` and `createModelProvider` from main index
- Add three example files demonstrating OpenRouter usage
- Add npm scripts for running OpenRouter examples

### Usage

```typescript
import { Agent, OpenRouterProvider, createModelProvider } from '@shareai-lab/kode-sdk';

// Direct usage
const provider = new OpenRouterProvider(apiKey, 'anthropic/claude-3.5-sonnet');

// Via factory function
const provider = createModelProvider({
  provider: 'openrouter',
  apiKey: 'YOUR_API_KEY',
  model: 'anthropic/claude-3.5-sonnet',
});

// Via Agent config
const agent = await Agent.create({
  templateId: 'my-template',
  modelConfig: {
    provider: 'openrouter',
    apiKey: 'YOUR_API_KEY',
    model: 'anthropic/claude-3.5-sonnet',
  },
}, deps);
```

### Credits
- PR #7 by @Maidang1 - Original OpenRouter implementation and providers directory structure
- PR #8 by @2217173240 - Cherry-pick and sync efforts  
- PR #9 by @fingertap - Robust implementation with retry logic and examples

### Related PRs
Closes #7, #8, #9

---
This PR takes the best parts from all three contributions:
- Directory structure from #7 (`src/infra/providers/`)
- Robust implementation from #9 (retry logic, better streaming)
- Examples adapted from #9