### PR TITLE
fix(core): resolve FilePool race condition in ensureWatch

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -1340,12 +1340,8 @@ export class Agent {
       };
       outcome = await this.hooks.runPostToolUse(outcome, context);
 
-      if (toolUse.name === 'fs_read' && toolUse.input?.path) {
-        await this.filePool.recordRead(toolUse.input.path);
-      }
-      if ((toolUse.name === 'fs_write' || toolUse.name === 'fs_edit' || toolUse.name === 'fs_multi_edit') && toolUse.input?.path) {
-        await this.filePool.recordEdit(toolUse.input.path);
-      }
+      // NOTE: recordRead/recordEdit 已在各工具内部调用，此处不再重复调用
+      // 参考: fs_read/index.ts:25, fs_write/index.ts:26, fs_edit/index.ts:29,53, fs_multi_edit/index.ts:60,92
 
       const success = outcome.ok !== false;
       const duration = Date.now() - (this.toolRecords.get(record.id)?.startedAt ?? Date.now());

--- a/tests/unit/core/file-pool.test.ts
+++ b/tests/unit/core/file-pool.test.ts
@@ -47,6 +47,62 @@ runner
 
     const status = await pool.checkFreshness('missing.txt');
     expect.toEqual(status.isFresh, false);
+  })
+
+  .test('并发 recordEdit 不会创建重复 watcher', async () => {
+    const dir = createTempDir('concurrent');
+    const filePath = path.join(dir, 'test.txt');
+    fs.writeFileSync(filePath, 'content');
+
+    const sandbox = new LocalSandbox({ workDir: dir, enforceBoundary: true, watchFiles: false });
+
+    // 追踪 watchFiles 调用次数
+    const watchCalls: string[] = [];
+    (sandbox as any).watchFiles = async (paths: string[]) => {
+      watchCalls.push(paths[0]);
+      await new Promise(r => setTimeout(r, 50)); // 模拟异步延迟
+      return `watch-${watchCalls.length}`;
+    };
+
+    const pool = new FilePool(sandbox, { watch: true });
+
+    // 并发调用 3 次 recordEdit
+    await Promise.all([
+      pool.recordEdit('test.txt'),
+      pool.recordEdit('test.txt'),
+      pool.recordEdit('test.txt'),
+    ]);
+
+    // 验证只创建了 1 个 watcher（per-path 锁生效）
+    expect.toEqual(watchCalls.length, 1);
+  })
+
+  .test('不同文件的并发 recordEdit 各自创建 watcher', async () => {
+    const dir = createTempDir('concurrent-multi');
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'a');
+    fs.writeFileSync(path.join(dir, 'b.txt'), 'b');
+    fs.writeFileSync(path.join(dir, 'c.txt'), 'c');
+
+    const sandbox = new LocalSandbox({ workDir: dir, enforceBoundary: true, watchFiles: false });
+
+    const watchCalls: string[] = [];
+    (sandbox as any).watchFiles = async (paths: string[]) => {
+      watchCalls.push(paths[0]);
+      await new Promise(r => setTimeout(r, 30));
+      return `watch-${watchCalls.length}`;
+    };
+
+    const pool = new FilePool(sandbox, { watch: true });
+
+    // 并发操作 3 个不同文件
+    await Promise.all([
+      pool.recordEdit('a.txt'),
+      pool.recordEdit('b.txt'),
+      pool.recordEdit('c.txt'),
+    ]);
+
+    // 每个文件各创建 1 个 watcher
+    expect.toEqual(watchCalls.length, 3);
   });
 
 export async function run() {


### PR DESCRIPTION
## 概述
  - 修复 `FilePool.ensureWatch()` 中的竞态条件，该问题可能导致重复创建 file watcher
  - 移除 Agent 层冗余的 `recordEdit()`/`recordRead()` 调用（工具内部已调用）
  - 添加并发文件操作的回归测试

  ## 问题描述

  `fs_write`/`fs_edit`/`fs_multi_edit`/`fs_read` 工具存在双重调用问题：
  1. 工具内部调用 `recordEdit()`/`recordRead()`
  2. Agent 层在工具执行后再次调用

  这导致 `ensureWatch()` 中出现竞态条件：
  T1: ensureWatch() -> has(path) = false -> await watchFiles()...
  T2: ensureWatch() -> has(path) = false -> await watchFiles()...  // 竞态!
  T3: T1 设置 watchers[path] = id1
  T4: T2 设置 watchers[path] = id2  // 覆盖，id1 成为孤儿

  后果：
  - 孤儿 watcher 导致资源泄漏
  - 可能耗尽 `fs.watch()` 系统限制

  ## 解决方案

  1. **移除冗余调用** (`agent.ts`)：工具内部已调用 `recordEdit()`/`recordRead()`，Agent 层无需重复
  2. **添加 per-path 锁** (`file-pool.ts`)：使用 `watchPending` Map 防止同一路径并发执行 `ensureWatch()`

  ## 测试验证
  - [x] 原有 226 个单元测试全部通过
  - [x] 新增测试：同一文件并发 `recordEdit()` 只创建 1 个 watcher
  - [x] 新增测试：不同文件并发 `recordEdit()` 各自创建独立 watcher
  - [x] 验证无修复时测试失败