### PR TITLE
feat(skills): 重构Skills系统管理器并更改默认目录

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ See [docs/en/guides/architecture.md](./docs/en/guides/architecture.md) for detai
 | **Guides** | |
 | [Events](./docs/en/guides/events.md) | Three-channel event system |
 | [Tools](./docs/en/guides/tools.md) | Built-in tools & custom tools |
+| [Skills](./docs/en/guides/skills.md) | Skills system for reusable prompts |
 | [Providers](./docs/en/guides/providers.md) | Model provider configuration |
 | [Database](./docs/en/guides/database.md) | SQLite/PostgreSQL persistence |
 | [Resume & Fork](./docs/en/guides/resume-fork.md) | Crash recovery & branching |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -102,6 +102,7 @@ npm run example:room               # 多Agent协作
 | **使用指南** | |
 | [事件系统](./docs/zh-CN/guides/events.md) | 三通道事件系统 |
 | [工具系统](./docs/zh-CN/guides/tools.md) | 内置工具与自定义工具 |
+| [Skills 系统](./docs/zh-CN/guides/skills.md) | Skills 可复用提示词系统 |
 | [Provider 配置](./docs/zh-CN/guides/providers.md) | 模型 Provider 配置 |
 | [数据库存储](./docs/zh-CN/guides/database.md) | SQLite/PostgreSQL 持久化 |
 | [恢复与分叉](./docs/zh-CN/guides/resume-fork.md) | 崩溃恢复与分支 |

--- a/docs/en/guides/tools.md
+++ b/docs/en/guides/tools.md
@@ -65,16 +65,18 @@ const agent = await Agent.create({
 
 ### Skills Tool
 
+> **⚠️ Note**: Default Skills directory has changed from `skills/` to `.skills/`. See [Skills System Guide - Breaking Changes](./skills.md#breaking-changes)
+
 - `skills`: Load specific skill content (instructions, references, scripts, assets)
   - **Parameters**:
-    - `action`: Operation type (currently only `load`)
+    - `action`: Operation type (currently only `load`, `list` operation is disabled)
     - `skill_name`: Skill name (required when action=load)
   - **Returns**:
     ```typescript
     {
       ok: true,
       data: {
-        name: string,           // Skill name
+        name: string,           // Skill name (folder name)
         description: string,    // Skill description
         content: string,        // SKILL.md content
         base_dir: string,       // Skill base directory

--- a/docs/zh-CN/guides/skills.md
+++ b/docs/zh-CN/guides/skills.md
@@ -2,6 +2,17 @@
 
 KODE SDK 提供完整的 Skills 系统，支持模块化、可重用的能力单元，使 Agent 能够动态加载和执行特定技能。
 
+> **⚠️ Breaking Changes - 重大变更**
+>
+> **默认 Skills 目录已从 `skills/` 更改为 `.skills/`**
+>
+> - 如果您未设置 `SKILLS_DIR` 环境变量，SkillsManager 现在将使用 `.skills/` 作为默认目录
+> - **影响范围**：所有未显式指定 skills 目录路径的代码
+> - **迁移方案**：
+>   - 方案 1：将现有的 `skills/` 目录重命名为 `.skills/`
+>   - 方案 2：设置环境变量 `SKILLS_DIR` 指向原目录（如 `export SKILLS_DIR=./skills`）
+>   - 方案 3：在代码中显式指定路径：`new SkillsManager('./skills')`
+
 ---
 
 ## 核心特性
@@ -11,14 +22,14 @@ KODE SDK 提供完整的 Skills 系统，支持模块化、可重用的能力单
 | **热重载** | Skills 代码修改后自动重新加载 |
 | **元数据注入** | 自动将技能描述注入到系统提示 |
 | **沙箱隔离** | 每个技能有独立的文件系统空间 |
-| **白名单机制** | 选择性加载特定技能 |
+| **白名单机制** | 选择性加载特定技能，支持 `["/*/"`](完全禁用) 和 `["*"]`(加载所有) 特殊配置 |
 
 ---
 
 ## 目录结构
 
 ```
-skills/
+.skills/
 ├── skill-name/              # 技能目录
 │   ├── SKILL.md            # 技能定义（必需）
 │   ├── metadata.json       # 技能元数据（可选）
@@ -69,17 +80,17 @@ skills/
 <!-- tabs:start -->
 #### **Linux / macOS**
 ```bash
-export SKILLS_DIR=/path/to/skills
+export SKILLS_DIR=/path/to/.skills
 ```
 
 #### **Windows (PowerShell)**
 ```powershell
-$env:SKILLS_DIR="/path/to/skills"
+$env:SKILLS_DIR="C:\path\to\.skills"
 ```
 
 #### **Windows (CMD)**
 ```cmd
-set SKILLS_DIR=/path/to/skills
+set SKILLS_DIR=C:\path\to\.skills
 ```
 <!-- tabs:end -->
 
@@ -96,7 +107,7 @@ import { SkillsManager } from '@shareai-lab/kode-sdk';
 
 // 创建 Skills 管理器
 const skillsManager = new SkillsManager(
-  './skills',           // 技能目录路径
+  './.skills',          // 技能目录路径（默认为 .skills）
   ['skill1', 'skill2']  // 可选：白名单
 );
 
@@ -130,68 +141,87 @@ await skillsManager.getSkillsMetadata();  // 扫描2，获取最新数据
 
 ```typescript
 // 只加载白名单中的技能
-const manager = new SkillsManager('./skills', ['allowed-skill-1', 'allowed-skill-2']);
+const manager = new SkillsManager('./.skills', ['allowed-skill-1', 'allowed-skill-2']);
 const skills = await manager.getSkillsMetadata();
 // 只返回白名单中的技能
+
+// 特殊配置：加载所有技能
+const managerAll = new SkillsManager('./.skills', ['*']);
+
+// 特殊配置：完全禁用技能功能
+const managerDisabled = new SkillsManager('./.skills', ['/*/']);
 ```
 
 ---
 
-## SkillsManagementManager（CRUD 操作）
+## SkillsManagementManager（管理操作）
 
-SkillsManagementManager 提供技能的 CRUD 操作，包括创建、更新、归档等。
+SkillsManagementManager 提供技能的完整管理操作，包括安装、导入、导出、归档等。
 
 ### 基本操作
 
 ```typescript
 import { SkillsManagementManager } from '@shareai-lab/kode-sdk';
 
-const manager = new SkillsManagementManager('./skills');
+const manager = new SkillsManagementManager('./.skills');
 
 // 列出所有在线技能
 const skills = await manager.listSkills();
 
-// 获取技能详细信息
-const skillDetail = await manager.getSkillInfo('skill-name');
-
-// 创建新技能
-await manager.createSkill('new-skill', {
-  description: '新技能描述',
-  content: '# 新技能\n\n详细内容...'
-});
-
-// 更新技能
-await manager.updateSkill('skill-name', {
-  content: '# 更新后的内容'
-});
-
-// 删除技能（移动到归档）
-await manager.deleteSkill('skill-name');
-
 // 列出已归档技能
 const archived = await manager.listArchivedSkills();
-
-// 恢复已归档技能
-await manager.restoreSkill('archived-skill');
 ```
 
-### 文件操作
+### 技能安装与导入
 
 ```typescript
-// 获取技能文件树
-const files = await manager.getSkillFileTree('skill-name');
+// 安装技能（从 GitHub 仓库、Git URL 或在线技能库）
+await manager.installSkill('github:user/repo');
 
-// 读取技能文件
-const content = await manager.readSkillFile('skill-name', 'SKILL.md');
+// 导入技能（从 zip 文件）
+await manager.importSkill('/path/to/skill.zip');
+```
 
-// 写入技能文件
-await manager.writeSkillFile('skill-name', 'references/doc.md', '内容');
+### 技能复制、重命名与归档
 
-// 删除技能文件
-await manager.deleteSkillFile('skill-name', 'references/old-doc.md');
+```typescript
+// 复制技能（自动添加随机后缀）
+const newSkillName = await manager.copySkill('skill-name');
 
-// 上传文件到技能目录
-await manager.uploadSkillFile('skill-name', 'assets/image.png', fileBuffer);
+// 重命名技能
+await manager.renameSkill('old-name', 'new-name');
+
+// 归档技能（移动到 .archived 目录）
+await manager.archiveSkill('skill-name');
+
+// 恢复已归档技能
+await manager.unarchiveSkill('archived-skill-abc12345');
+```
+
+### 查看技能内容与结构
+
+```typescript
+// 查看在线技能内容（SKILL.md 完整内容）
+const content = await manager.getOnlineSkillContent('skill-name');
+
+// 查看归档技能内容
+const archivedContent = await manager.getArchivedSkillContent('archived-skill-abc12345');
+
+// 获取在线技能文件目录结构
+const structure = await manager.getOnlineSkillStructure('skill-name');
+
+// 获取归档技能文件目录结构
+const archivedStructure = await manager.getArchivedSkillStructure('archived-skill-abc12345');
+```
+
+### 导出技能
+
+```typescript
+// 导出在线技能到 zip 文件
+const zipPath = await manager.exportSkill('skill-name', false);
+
+// 导出归档技能到 zip 文件
+const archivedZipPath = await manager.exportSkill('archived-skill-abc12345', true);
 ```
 
 ---
@@ -205,8 +235,8 @@ import { Agent, createSkillsTool, SkillsManager } from '@shareai-lab/kode-sdk';
 
 const deps = createDependencies();
 
-// 创建 Skills 管理器
-const skillsManager = new SkillsManager('./skills');
+// 创建 Skills 管理器（默认使用 .skills 目录）
+const skillsManager = new SkillsManager('./.skills');
 
 // 注册 Skills 工具
 const skillsTool = createSkillsTool(skillsManager);
@@ -247,12 +277,15 @@ Agent: 已加载代码格式化技能。现在我可以帮你格式化代码了�
 ### 2. 白名单管理
 
 ```typescript
-// 生产环境使用白名单
+// 生产环境：使用白名单限制加载的技能
 const allowedSkills = ['safe-skill-1', 'safe-skill-2'];
-const manager = new SkillsManager('./skills', allowedSkills);
+const manager = new SkillsManager('./.skills', allowedSkills);
 
-// 开发环境加载所有技能
-const devManager = new SkillsManager('./skills');
+// 开发环境：加载所有技能
+const devManager = new SkillsManager('./.skills', ['*']);
+
+// 生产环境：完全禁用技能功能
+const disabledManager = new SkillsManager('./.skills', ['/*/']);
 ```
 
 ### 3. 错误处理

--- a/docs/zh-CN/guides/tools.md
+++ b/docs/zh-CN/guides/tools.md
@@ -65,16 +65,18 @@ const agent = await Agent.create({
 
 ### Skills 工具
 
+> **⚠️ 注意**：默认 Skills 目录已从 `skills/` 更改为 `.skills/`，详见 [Skills 系统指南 - Breaking Changes](./skills.md#breaking-changes)
+
 - `skills`：加载特定技能的详细内容（包含指令、references、scripts、assets）
   - **参数**：
-    - `action`：操作类型（目前仅支持 `load`）
+    - `action`：操作类型（目前仅支持 `load`，`list` 操作已禁用）
     - `skill_name`：技能名称（当 action=load 时必需）
   - **返回**：
     ```typescript
     {
       ok: true,
       data: {
-        name: string,           // 技能名称
+        name: string,           // 技能名称（文件夹名称）
         description: string,    // 技能描述
         content: string,        // SKILL.md 内容
         base_dir: string,       // 技能基础目录

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "fast-glob": "^3.3.2",
     "pg": "^8.17.2",
     "undici": "^7.18.2",
-    "zod": "~3.23.8",
-    "zod-to-json-schema": "~3.23.0"
+    "zod": "^4.3.5",
+    "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@shareai-lab/kode-sdk": "file:.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,29 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.19.1
-        version: 1.25.1(hono@4.11.3)(zod@4.3.5)
+        specifier: ~1.22.0
+        version: 1.22.0
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.6.2
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      e2b:
+        specifier: ^2.10.3
+        version: 2.12.0
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.3
+      pg:
+        specifier: ^8.17.2
+        version: 8.17.2
+      undici:
+        specifier: ^7.18.2
+        version: 7.19.2
       zod:
         specifier: ^4.3.5
         version: 4.3.5
@@ -28,11 +40,17 @@ importers:
         version: 3.25.1(zod@4.3.5)
     devDependencies:
       '@shareai-lab/kode-sdk':
-        specifier: ^1.0.0-beta.9
-        version: 1.0.0-beta.9
+        specifier: file:.
+        version: 'file:'
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.27
+      '@types/pg':
+        specifier: ^8.16.0
+        version: 8.16.0
       ts-node:
         specifier: ^10.9.0
         version: 10.9.2(@types/node@20.19.27)(typescript@5.9.3)
@@ -42,15 +60,39 @@ importers:
 
 packages:
 
+  '@bufbuild/protobuf@2.11.0':
+    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
+  '@connectrpc/connect-web@2.0.0-rc.3':
+    resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+      '@connectrpc/connect': 2.0.0-rc.3
+
+  '@connectrpc/connect@2.0.0-rc.3':
+    resolution: {integrity: sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@hono/node-server@1.19.7':
-    resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -62,12 +104,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@modelcontextprotocol/sdk@1.25.1':
-    resolution: {integrity: sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==}
+  '@modelcontextprotocol/sdk@1.22.0':
+    resolution: {integrity: sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -84,8 +125,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@shareai-lab/kode-sdk@1.0.0-beta.9':
-    resolution: {integrity: sha512-vr7n5qCGG/qhvqgqydubIFhmkx+UAYdqgXo9KVbWlM984PxcweDS+SVX7dL6TwFooWhzRn08JeB/7IHZv0LQ8A==}
+  '@shareai-lab/kode-sdk@file:':
+    resolution: {directory: '', type: directory}
     engines: {node: '>=18.0.0'}
 
   '@tsconfig/node10@1.0.12':
@@ -100,8 +141,14 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
+
+  '@types/pg@8.16.0':
+    resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -127,8 +174,37 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@12.6.2:
+    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   body-parser@2.2.1:
     resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
@@ -137,6 +213,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -149,6 +228,27 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -186,13 +286,28 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  dockerfile-ast@0.7.1:
+    resolution: {integrity: sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -202,12 +317,28 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  e2b@2.12.0:
+    resolution: {integrity: sha512-uzMEg11JQ6o90ODBUgPaQXKJ3tQNiQMAYi5yU5jK60Y0l+CSs7U8qoQcgTiSCemkIEyrmIDFub/ega8dv5vMCw==}
+    engines: {node: '>=20'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -236,6 +367,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
     engines: {node: '>= 16'}
@@ -259,6 +394,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -267,6 +405,10 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -274,6 +416,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -286,9 +431,17 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -302,10 +455,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.11.3:
-    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
-    engines: {node: '>=16.9.0'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -314,8 +463,14 @@ packages:
     resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -324,6 +479,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -339,14 +498,16 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+  lru-cache@11.2.5:
+    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
+    engines: {node: 20 || >=22}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -379,12 +540,41 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-abi@3.87.0:
+    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
+    engines: {node: '>=10'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -401,6 +591,15 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openapi-fetch@0.14.1:
+    resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -409,8 +608,46 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-scurry@2.0.1:
+    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
+    engines: {node: 20 || >=22}
+
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.10.1:
+    resolution: {integrity: sha512-iNzslsoeSH2/gmDDKiyMqF64DATUCWj3YJ0wP14kqcsf2TUklwimd+66yYojKwZCA7h2yRNLGug71hCBA2a4sw==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.11.0:
+    resolution: {integrity: sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.11.0:
+    resolution: {integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.17.2:
+    resolution: {integrity: sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -420,9 +657,36 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
@@ -439,6 +703,14 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -454,8 +726,16 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
@@ -492,9 +772,57 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar@7.5.7:
+    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+    engines: {node: '>=18'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -518,6 +846,9 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -530,9 +861,16 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.19.2:
+    resolution: {integrity: sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==}
+    engines: {node: '>=20.18.1'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -541,13 +879,35 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -558,18 +918,47 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
 snapshots:
 
+  '@bufbuild/protobuf@2.11.0': {}
+
+  '@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)
+
+  '@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@hono/node-server@1.19.7(hono@4.11.3)':
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
     dependencies:
-      hono: 4.11.3
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -580,9 +969,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.3)(zod@4.3.5)':
+  '@modelcontextprotocol/sdk@1.22.0':
     dependencies:
-      '@hono/node-server': 1.19.7(hono@4.11.3)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -592,14 +980,11 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 7.5.1(express@5.2.1)
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.5
-      zod-to-json-schema: 3.25.1(zod@4.3.5)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
-      - hono
       - supports-color
 
   '@nodelib/fs.scandir@2.1.5':
@@ -614,7 +999,22 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@shareai-lab/kode-sdk@1.0.0-beta.9': {}
+  '@shareai-lab/kode-sdk@file:':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.22.0
+      ajv: 8.17.1
+      better-sqlite3: 12.6.2
+      dotenv: 16.6.1
+      e2b: 2.12.0
+      fast-glob: 3.3.3
+      pg: 8.17.2
+      undici: 7.19.2
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - pg-native
+      - supports-color
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -624,9 +1024,19 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 20.19.27
+
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.16.0':
+    dependencies:
+      '@types/node': 20.19.27
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
 
   accepts@2.0.0:
     dependencies:
@@ -650,7 +1060,34 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
   arg@4.1.3: {}
+
+  base64-js@1.5.1: {}
+
+  better-sqlite3@12.6.2:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@2.2.1:
     dependencies:
@@ -670,6 +1107,11 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -681,6 +1123,20 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  chalk@5.6.2: {}
+
+  chownr@1.1.4: {}
+
+  chownr@3.0.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  compare-versions@6.1.1: {}
 
   content-disposition@1.0.1: {}
 
@@ -707,9 +1163,22 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   depd@2.0.0: {}
 
+  detect-libc@2.1.2: {}
+
   diff@4.0.2: {}
+
+  dockerfile-ast@0.7.1:
+    dependencies:
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
 
   dotenv@16.6.1: {}
 
@@ -719,9 +1188,32 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  e2b@2.12.0:
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)
+      '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0))
+      chalk: 5.6.2
+      compare-versions: 6.1.1
+      dockerfile-ast: 0.7.1
+      glob: 11.1.0
+      openapi-fetch: 0.14.1
+      platform: 1.3.6
+      tar: 7.5.7
+
+  eastasianwidth@0.2.0: {}
+
   ee-first@1.1.1: {}
 
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   es-define-property@1.0.1: {}
 
@@ -740,6 +1232,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
+
+  expand-template@2.0.3: {}
 
   express-rate-limit@7.5.1(express@5.2.1):
     dependencies:
@@ -794,6 +1288,8 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -809,9 +1305,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   function-bind@1.1.2: {}
 
@@ -833,9 +1336,20 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  github-from-package@0.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.1
 
   gopd@1.2.0: {}
 
@@ -844,8 +1358,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  hono@4.11.3: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -859,11 +1371,17 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -875,11 +1393,13 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jose@6.1.3: {}
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
 
   json-schema-traverse@1.0.0: {}
 
-  json-schema-typed@8.0.2: {}
+  lru-cache@11.2.5: {}
 
   make-error@1.3.6: {}
 
@@ -902,9 +1422,31 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-response@3.1.0: {}
+
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.2: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.2
+
+  mkdirp-classic@0.5.3: {}
+
   ms@2.1.3: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@1.0.0: {}
+
+  node-abi@3.87.0:
+    dependencies:
+      semver: 7.7.3
 
   object-assign@4.1.1: {}
 
@@ -918,20 +1460,100 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  openapi-fetch@0.14.1:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  package-json-from-dist@1.0.1: {}
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
 
+  path-scurry@2.0.1:
+    dependencies:
+      lru-cache: 11.2.5
+      minipass: 7.1.2
+
   path-to-regexp@8.3.0: {}
+
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.10.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.11.0(pg@8.17.2):
+    dependencies:
+      pg: 8.17.2
+
+  pg-protocol@1.11.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.17.2:
+    dependencies:
+      pg-connection-string: 2.10.1
+      pg-pool: 3.11.0(pg@8.17.2)
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picomatch@2.3.1: {}
 
   pkce-challenge@5.0.1: {}
 
+  platform@1.3.6: {}
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.87.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   qs@6.14.1:
     dependencies:
@@ -947,6 +1569,19 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   require-from-string@2.0.2: {}
 
@@ -966,7 +1601,11 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
+
+  semver@7.7.3: {}
 
   send@1.2.1:
     dependencies:
@@ -1029,7 +1668,68 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  split2@4.2.0: {}
+
   statuses@2.0.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-json-comments@2.0.1: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar@7.5.7:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   to-regex-range@5.0.1:
     dependencies:
@@ -1055,6 +1755,10 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -1065,22 +1769,52 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.19.2: {}
+
   unpipe@1.0.0: {}
+
+  util-deprecate@1.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
   vary@1.1.2: {}
 
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
+
   wrappy@1.0.2: {}
 
+  xtend@4.0.2: {}
+
+  yallist@5.0.0: {}
+
   yn@3.1.1: {}
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-to-json-schema@3.25.1(zod@4.3.5):
     dependencies:
       zod: 4.3.5
+
+  zod@3.25.76: {}
 
   zod@4.3.5: {}

--- a/src/core/skills/management-manager.ts
+++ b/src/core/skills/management-manager.ts
@@ -1,606 +1,794 @@
 /**
- * 技能管理器模块（路径1 - 技能管理）
+ * 技能管理器模块(路径1 - 技能管理)
  *
  * 设计原则 (UNIX哲学):
- * - 简洁: 只负责技能文件系统的CRUD操作
- * - 模块化: 协调OperationQueue、SandboxFileManager进行文件系统操作
- * - 隔离: 与Agent运行时完全隔离，不参与Agent使用
+ * - 简洁: 只负责技能文件系统的管理操作
+ * - 模块化: 单一职责,易于测试和维护
+ * - 隔离: 与Agent运行时完全隔离,不参与Agent使用
  *
  * ⚠️ 重要说明:
- * - 此模块专门用于路径1（技能管理）
- * - 与路径2（Agent运行时）完全独立
+ * - 此模块专门用于路径1(技能管理)
+ * - 与路径2(Agent运行时)完全独立
  * - 请勿与SkillsManager混淆
+ *
+ * @see docs/skills-management-implementation-plan.md
  */
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import * as os from 'os';
 import * as crypto from 'crypto';
-import { SkillsManager } from './manager';
-import { OperationQueue, OperationType, OperationTask } from './operation-queue';
-import { SandboxFileManager } from './sandbox-file-manager';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import type {
   SkillInfo,
-  SkillDetail,
-  SkillFileTree,
-  CreateSkillOptions,
   ArchivedSkillInfo,
 } from './types';
-import { SandboxFactory } from '../../infra/sandbox-factory';
 import { logger } from '../../utils/logger';
+
+const execAsync = promisify(exec);
 
 /**
  * 技能管理器类
  *
  * 职责:
- * - 提供所有技能管理操作的统一接口（CRUD操作）
- * - 协调OperationQueue、SandboxFileManager进行文件系统操作
+ * - 提供所有技能管理操作的统一接口(导入、复制、重命名、归档、导出)
  * - 处理业务逻辑和权限验证
+ * - 所有操作严格遵循Specification.md规范
  * - ❌ 不参与Agent运行时
  * - ❌ 不提供技能加载、扫描等Agent使用的功能
  */
 export class SkillsManagementManager {
-  private skillsManager: SkillsManager;
-  private operationQueue: OperationQueue;
-  private sandboxFileManager: SandboxFileManager;
   private skillsDir: string;
-  private archivedDir: string;  // 归档目录：skills/.archived/
+  private archivedDir: string;  // 归档目录: skills/.archived/
 
   constructor(
     skillsDir: string,
-    sandboxFactory?: SandboxFactory,
-    archivedDir?: string  // 可选，默认为 skills/.archived/
+    archivedDir?: string  // 可选,默认为 skills/.archived/
   ) {
     this.skillsDir = path.resolve(skillsDir);
     this.archivedDir = archivedDir ? path.resolve(archivedDir) : path.join(this.skillsDir, '.archived');
-    this.skillsManager = new SkillsManager(this.skillsDir);
-    this.operationQueue = new OperationQueue();
-    this.sandboxFileManager = new SandboxFileManager(
-      sandboxFactory || new SandboxFactory()
-    );
 
     logger.log(`[SkillsManagementManager] Initialized with skills directory: ${this.skillsDir}`);
     logger.log(`[SkillsManagementManager] Archived directory: ${this.archivedDir}`);
   }
 
+  // ==================== 公共方法(8个核心操作) ====================
+
   /**
-   * 获取所有在线技能列表（不包含archived技能）
+   * 1. 列出在线技能
+   * 扫描skills目录,排除.archived子目录
+   * 返回技能清单及其元数据信息
    */
   async listSkills(): Promise<SkillInfo[]> {
-    // 扫描所有技能
-    const allSkills = await this.skillsManager.getSkillsMetadata();
-
-    // 过滤掉archived技能（排除.archived目录）
-    const onlineSkills = allSkills.filter((skill) => {
-      return !skill.baseDir.includes('/.archived/') &&
-             !skill.baseDir.includes('\\.archived\\');
-    });
-
-    // 添加文件统计信息
-    const skillsWithInfo: SkillInfo[] = [];
-    for (const skill of onlineSkills) {
-      const stat = await this.safeGetFileStat(skill.path);
-      skillsWithInfo.push({
-        ...skill,
-        createdAt: stat?.birthtime?.toISOString(),
-        updatedAt: stat?.mtime?.toISOString(),
-      });
-    }
-
-    return skillsWithInfo;
-  }
-
-  /**
-   * 获取单个在线技能详细信息
-   * @param skillName 技能名称
-   */
-  async getSkillInfo(skillName: string): Promise<SkillDetail | null> {
-    // 检查技能是否在线（不在archived中）
-    const skill = await this.skillsManager.loadSkillContent(skillName);
-    if (!skill) {
-      return null;
-    }
-
-    // 验证技能不是archived（排除.archived目录）
-    if (skill.metadata.baseDir.includes('/.archived/') ||
-        skill.metadata.baseDir.includes('\\.archived\\')) {
-      throw new Error(`Cannot get info for archived skill: ${skillName}`);
-    }
-
-    // 获取文件树
-    const files = await this.getSkillFileTree(skillName);
-
-    // 获取文件统计信息
-    const stat = await this.safeGetFileStat(skill.metadata.path);
-
-    return {
-      name: skill.metadata.name,
-      description: skill.metadata.description,
-      path: skill.metadata.path,
-      baseDir: skill.metadata.baseDir,
-      createdAt: stat?.birthtime?.toISOString(),
-      updatedAt: stat?.mtime?.toISOString(),
-      files,
-      references: skill.references,
-      scripts: skill.scripts,
-      assets: skill.assets,
-    };
-  }
-
-  /**
-   * 获取已归档技能列表（只读，不支持修改）
-   */
-  async listArchivedSkills(): Promise<ArchivedSkillInfo[]> {
-    // 使用配置的归档目录
-    const archivedDir = this.archivedDir;
-
-    // 检查archived目录是否存在
-    const exists = await this.fileExists(archivedDir);
-    if (!exists) {
-      return [];
-    }
+    const skills: SkillInfo[] = [];
 
     try {
-      // 读取archived目录
-      const entries = await fs.readdir(archivedDir, { withFileTypes: true });
+      // 1. 读取skills目录
+      const entries = await fs.readdir(this.skillsDir, { withFileTypes: true });
 
-      const archivedSkills: ArchivedSkillInfo[] = [];
+      // 2. 遍历每个子目录
       for (const entry of entries) {
-        if (!entry.isDirectory()) {
-          continue;
-        }
+        // 排除.archived目录
+        if (entry.name === '.archived') continue;
 
-        const archivedPath = path.join(archivedDir, entry.name);
+        // 只处理目录
+        if (!entry.isDirectory()) continue;
 
-        // 检查是否包含SKILL.md
-        const skillMdPath = path.join(archivedPath, 'SKILL.md');
-        if (!(await this.fileExists(skillMdPath))) {
-          continue;
-        }
+        const skillDir = path.join(this.skillsDir, entry.name);
 
-        // 提取原始名称和归档时间（支持带毫秒和不带毫秒两种格式）
-        const match = entry.name.match(/^(.+?)_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3})?Z)$/);
-        if (!match) {
-          continue;
-        }
+        // 3. 读取SKILL.md
+        const skillMdPath = path.join(skillDir, 'SKILL.md');
+        const exists = await this.fileExists(skillMdPath);
+        if (!exists) continue; // 跳过没有SKILL.md的目录
 
-        const originalName = match[1];
+        const content = await fs.readFile(skillMdPath, 'utf-8');
 
-        // 解析时间戳（支持带毫秒和不带毫秒两种格式）
-        // 格式1: 2026-01-15T05-05-01-350Z (带毫秒)
-        // 格式2: 2026-01-15T05-05-01Z (不带毫秒)
-        const timestampMatch = match[2].match(/^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})(?:-(\d{3}))?Z$/);
-        if (!timestampMatch) {
-          continue;
-        }
-        const [, date, hour, min, sec, ms] = timestampMatch;
-        const isoTimestamp = ms
-          ? `${date}T${hour}:${min}:${sec}.${ms}Z`
-          : `${date}T${hour}:${min}:${sec}Z`;
-        const archivedAt = new Date(isoTimestamp).toISOString();
+        // 4. 解析YAML frontmatter
+        const metadata = this.parseSkillMd(content);
+        if (!metadata) continue; // 跳过无效的SKILL.md
 
         // 获取文件统计信息
-        const stat = await this.safeGetFileStat(archivedPath);
+        const stat = await this.safeGetFileStat(skillMdPath);
 
-        archivedSkills.push({
-          originalName,
-          archivedName: entry.name,
-          archivedPath,
-          archivedAt: stat?.mtime?.toISOString() || archivedAt,
+        skills.push({
+          name: metadata.name || entry.name,
+          description: metadata.description || '',
+          path: skillMdPath,
+          baseDir: skillDir,
+          folderName: entry.name,
+          createdAt: stat?.birthtime?.toISOString(),
+          updatedAt: stat?.mtime?.toISOString(),
         });
       }
 
-      return archivedSkills.sort((a, b) =>
-        b.archivedAt.localeCompare(a.archivedAt)
-      );
+      return skills;
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error listing skills:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 2. 安装新技能
+   * @param source 技能来源(名称/GitHub仓库/Git URL/本地路径)
+   * @param onProgress 可选的进度回调函数，用于实时传递安装日志
+   * 执行命令: npx -y ai-agent-skills install --agent project [source]
+   * 直接安装到.skills目录
+   */
+  async installSkill(source: string, onProgress?: (data: { type: 'log' | 'error'; message: string }) => void): Promise<void> {
+    try {
+      // 验证source参数
+      if (!source || source.trim().length === 0) {
+        throw new Error('技能来源不能为空');
+      }
+
+      // 构建命令
+      const command = `npx -y ai-agent-skills install --agent project ${source.trim()}`;
+
+      logger.log(`[SkillsManagementManager] 正在安装技能: ${source}`);
+      onProgress?.({ type: 'log', message: `正在安装技能: ${source}` });
+
+      // 使用spawn替代execAsync以获取实时输出
+      const { spawn } = require('child_process');
+
+      return new Promise((resolve, reject) => {
+        // 使用父目录作为工作目录，避免在.skills内再创建.skills
+        const cwd = path.dirname(this.skillsDir);
+        const child = spawn(command, [], {
+          cwd,
+          shell: true,
+          env: { ...process.env }
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let hasError = false;
+
+        // 检测错误关键词的辅助函数
+        const checkErrorKeywords = (text: string): boolean => {
+          const trimmed = text.trim();
+          // 移除ANSI颜色码
+          const cleanText = trimmed.replace(/\u001b\[\d+m/g, '');
+
+          return cleanText.includes('not found') ||
+                 cleanText.includes('ERROR') ||
+                 cleanText.includes('error:') ||
+                 cleanText.includes('Failed to') ||
+                 cleanText.includes('Cannot find');
+        };
+
+        // 监听标准输出
+        child.stdout?.on('data', (data: Buffer) => {
+          const message = data.toString();
+          stdout += message;
+          const trimmed = message.trim();
+
+          // 检测stdout中的错误关键词
+          if (checkErrorKeywords(trimmed)) {
+            hasError = true;
+          }
+
+          logger.log(`[SkillsManagementManager] ${trimmed}`);
+          onProgress?.({ type: 'log', message: trimmed });
+        });
+
+        // 监听错误输出
+        child.stderr?.on('data', (data: Buffer) => {
+          const message = data.toString();
+          stderr += message;
+          const trimmed = message.trim();
+
+          // 检测stderr中的错误关键词
+          if (checkErrorKeywords(trimmed)) {
+            hasError = true;
+          }
+
+          logger.warn(`[SkillsManagementManager] ${trimmed}`);
+          onProgress?.({ type: 'error', message: trimmed });
+        });
+
+        // 监听进程退出
+        child.on('close', (code: number) => {
+          // 检查是否有错误标识或退出码非0
+          if (code !== 0 || hasError) {
+            let errorMsg = '';
+            if (hasError) {
+              // 从stderr中提取关键错误信息
+              const errorLines = stderr.split('\n').filter((line: string) =>
+                line.includes('not found') ||
+                line.includes('ERROR') ||
+                line.includes('error:') ||
+                line.includes('Failed') ||
+                line.includes('Cannot')
+              );
+              errorMsg = errorLines.length > 0 ? errorLines[0].trim() : '安装过程中出现错误';
+            } else {
+              errorMsg = `安装进程退出码: ${code}`;
+            }
+
+            logger.error(`[SkillsManagementManager] 安装失败: ${errorMsg}`);
+            reject(new Error(`安装技能失败: ${errorMsg}`));
+          } else {
+            logger.log(`[SkillsManagementManager] 技能已安装: ${source}`);
+            resolve();
+          }
+        });
+
+        // 监听错误
+        child.on('error', (error: Error) => {
+          const errorMsg = `启动安装进程失败: ${error.message}`;
+          logger.error(`[SkillsManagementManager] ${errorMsg}`);
+          onProgress?.({ type: 'error', message: errorMsg });
+          reject(new Error(`安装技能失败: ${errorMsg}`));
+        });
+      });
+    } catch (error: any) {
+      logger.error(`[SkillsManagementManager] 安装技能失败: ${error.message}`);
+      onProgress?.({ type: 'error', message: error.message });
+      throw new Error(`安装技能失败: ${error.message}`);
+    }
+  }
+
+  /**
+   * 3. 列出归档技能
+   * 扫描.archived目录
+   * 返回归档技能清单及其元数据信息
+   */
+  async listArchivedSkills(): Promise<ArchivedSkillInfo[]> {
+    const skills: ArchivedSkillInfo[] = [];
+
+    try {
+      // 1. 确保.archived目录存在
+      const exists = await this.fileExists(this.archivedDir);
+      if (!exists) {
+        return skills; // 返回空列表
+      }
+
+      // 2. 读取.archived目录
+      const entries = await fs.readdir(this.archivedDir, { withFileTypes: true });
+
+      // 3. 遍历每个子目录
+      for (const entry of entries) {
+        // 只处理目录
+        if (!entry.isDirectory()) continue;
+
+        const skillDir = path.join(this.archivedDir, entry.name);
+
+        // 4. 读取SKILL.md
+        const skillMdPath = path.join(skillDir, 'SKILL.md');
+        const skillExists = await this.fileExists(skillMdPath);
+        if (!skillExists) continue; // 跳过没有SKILL.md的目录
+
+        const content = await fs.readFile(skillMdPath, 'utf-8');
+
+        // 5. 解析YAML frontmatter
+        const metadata = this.parseSkillMd(content);
+        if (!metadata) continue; // 跳过无效的SKILL.md
+
+        // 6. 提取原始技能名称(去除-XXXXXXXX后缀)
+        const match = entry.name.match(/^(.+)-[a-f0-9]{8}$/);
+        const originalName = match ? match[1] : entry.name;
+
+        // 获取文件统计信息
+        const stat = await this.safeGetFileStat(skillDir);
+
+        skills.push({
+          originalName: originalName,
+          archivedName: entry.name,
+          archivedPath: skillDir,
+          folderName: entry.name,
+          archivedAt: stat?.mtime?.toISOString() || new Date().toISOString(),
+          name: metadata.name,
+          description: metadata.description,
+          license: metadata.license,
+        });
+      }
+
+      return skills;
     } catch (error: any) {
       logger.error('[SkillsManagementManager] Error listing archived skills:', error);
-      return [];
+      throw error;
     }
   }
 
   /**
-   * 创建新技能
-   * @param skillName 技能名称
-   * @param options 技能配置（名称、描述等）
+   * 4. 导入技能
+   * @param zipFilePath zip文件路径
+   * @param originalFileName 原始上传文件名（可选，用于无嵌套目录时的技能命名）
+   * 验证SKILL.md格式,解压并放置在在线技能目录中
+   *
+   * 检测逻辑：
+   * - 如果解压后根目录直接包含SKILL.md，视为无嵌套目录，使用originalFileName作为技能名称
+   * - 如果根目录不包含SKILL.md但包含多个子目录，每个子目录都有SKILL.md，则批量导入
    */
-  async createSkill(
-    skillName: string,
-    options: CreateSkillOptions
-  ): Promise<SkillDetail> {
-    // 包装为操作任务
-    const task: OperationTask = {
-      id: crypto.randomUUID(),
-      type: OperationType.CREATE,
-      targetSkill: skillName,
-      status: 'pending' as any,
-      execute: async () => {
-        await this.doCreateSkill(skillName, options);
-      },
-      createdAt: new Date(),
-    };
+  async importSkill(zipFilePath: string, originalFileName?: string): Promise<void> {
+    try {
+      // 1. 验证zip文件存在
+      const exists = await this.fileExists(zipFilePath);
+      if (!exists) {
+        throw new Error(`Zip文件不存在: ${zipFilePath}`);
+      }
 
-    // 入队并等待完成
-    await this.operationQueue.enqueue(task);
-    await this.waitForTask(task);
+      // 2. 创建临时目录
+      const tempDir = path.join(os.tmpdir(), `skill-import-${Date.now()}`);
+      await fs.mkdir(tempDir, { recursive: true });
 
-    // 检查是否有错误
-    if (task.error) {
-      throw task.error;
+      try {
+        // 3. 解压zip文件
+        await this.extractZip(zipFilePath, tempDir);
+
+        // 4. 检测结构
+        const rootSkillMdPath = path.join(tempDir, 'SKILL.md');
+        const hasRootSkillMd = await this.fileExists(rootSkillMdPath);
+
+        if (hasRootSkillMd && originalFileName) {
+          // 4.1 无嵌套目录结构：根目录直接包含SKILL.md
+          // 使用原始文件名（去除.zip扩展名）作为技能名称
+          let skillName = originalFileName.replace(/\.zip$/i, '');
+
+          // 验证SKILL.md
+          const valid = await this.validateSkillMd(rootSkillMdPath);
+          if (!valid) {
+            throw new Error('技能格式无效, SKILL.md不符合Specification.md规范');
+          }
+
+          // 检测重名，如重名则添加后缀
+          let targetDir = path.join(this.skillsDir, skillName);
+          if (await this.fileExists(targetDir)) {
+            const suffix = await this.generateRandomSuffix();
+            const newName = `${skillName}-${suffix}`;
+            targetDir = path.join(this.skillsDir, newName);
+            logger.log(`[SkillsManagementManager] 导入技能重名，已添加后缀: ${skillName} -> ${newName}`);
+            skillName = newName;
+          }
+
+          // 移动到在线技能目录
+          await this.safeRename(tempDir, targetDir);
+          logger.log(`[SkillsManagementManager] 技能已导入: ${skillName}`);
+        } else {
+          // 4.2 嵌套目录结构：批量导入多个技能目录
+          const entries = await fs.readdir(tempDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+
+            const skillDir = path.join(tempDir, entry.name);
+
+            // 验证SKILL.md
+            const skillMdPath = path.join(skillDir, 'SKILL.md');
+            const valid = await this.validateSkillMd(skillMdPath);
+            if (!valid) {
+              throw new Error(`技能格式无效: ${entry.name}, SKILL.md不符合Specification.md规范`);
+            }
+
+            // 检测重名，如重名则添加后缀
+            let targetName = entry.name;
+            let targetDir = path.join(this.skillsDir, targetName);
+
+            if (await this.fileExists(targetDir)) {
+              // 重名，添加随机后缀
+              const suffix = await this.generateRandomSuffix();
+              targetName = `${entry.name}-${suffix}`;
+              targetDir = path.join(this.skillsDir, targetName);
+              logger.log(`[SkillsManagementManager] 导入技能重名，已添加后缀: ${entry.name} -> ${targetName}`);
+            }
+
+            // 移动到在线技能目录
+            await this.safeRename(skillDir, targetDir);
+            logger.log(`[SkillsManagementManager] 技能已导入: ${targetName}`);
+          }
+        }
+      } finally {
+        // 5. 清理临时目录
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error importing skill:', error);
+      throw error;
     }
-
-    // 返回创建的技能详细信息
-    const skillDetail = await this.getSkillInfo(skillName);
-    if (!skillDetail) {
-      throw new Error(`Failed to get skill info after creation: ${skillName}`);
-    }
-    return skillDetail;
   }
 
   /**
-   * 重命名技能
-   * @param oldName 旧技能名称
-   * @param newName 新技能名称
+   * 5. 复制技能
+   * @param skillName 技能名称
+   * 新技能名称: {原技能名称}-{XXXXXXXX}
+   */
+  async copySkill(skillName: string): Promise<string> {
+    try {
+      // 1. 验证技能存在
+      const sourceDir = path.join(this.skillsDir, skillName);
+      const exists = await this.fileExists(sourceDir);
+      if (!exists) {
+        throw new Error(`技能不存在: ${skillName}`);
+      }
+
+      // 2. 生成8位随机后缀
+      const suffix = await this.generateRandomSuffix();
+      const newSkillName = `${skillName}-${suffix}`;
+      const targetDir = path.join(this.skillsDir, newSkillName);
+
+      // 3. 递归复制目录
+      await fs.cp(sourceDir, targetDir, { recursive: true });
+      logger.log(`[SkillsManagementManager] 技能已复制: ${skillName} -> ${newSkillName}`);
+
+      return newSkillName;
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error copying skill:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 6. 重命名技能
+   * @param oldName 旧技能文件夹名称
+   * @param newName 新技能文件夹名称
+   * 不支持操作归档技能
    */
   async renameSkill(oldName: string, newName: string): Promise<void> {
-    // 包装为操作任务
-    const task: OperationTask = {
-      id: crypto.randomUUID(),
-      type: OperationType.RENAME,
-      targetSkill: `${oldName} -> ${newName}`,
-      status: 'pending' as any,
-      execute: async () => {
-        await this.doRenameSkill(oldName, newName);
-      },
-      createdAt: new Date(),
-    };
-
-    // 入队并等待完成
-    await this.operationQueue.enqueue(task);
-    await this.waitForTask(task);
-
-    // 检查是否有错误
-    if (task.error) {
-      throw task.error;
-    }
-  }
-
-  /**
-   * 编辑技能文件
-   * @param skillName 技能名称
-   * @param filePath 文件路径（相对于技能根目录，如"SKILL.md"）
-   * @param content 文件内容
-   * @param useSandbox 是否使用sandbox（默认true）
-   */
-  async editSkillFile(
-    skillName: string,
-    filePath: string,
-    content: string,
-    useSandbox: boolean = true
-  ): Promise<void> {
-    // 包装为操作任务
-    const task: OperationTask = {
-      id: crypto.randomUUID(),
-      type: OperationType.EDIT,
-      targetSkill: skillName,
-      status: 'pending' as any,
-      execute: async () => {
-        await this.doEditSkillFile(skillName, filePath, content, useSandbox);
-      },
-      createdAt: new Date(),
-    };
-
-    // 入队并等待完成
-    await this.operationQueue.enqueue(task);
-    await this.waitForTask(task);
-
-    // 检查是否有错误
-    if (task.error) {
-      throw task.error;
-    }
-  }
-
-  /**
-   * 删除技能（移动到archived）
-   * @param skillName 技能名称
-   */
-  async deleteSkill(skillName: string): Promise<void> {
-    // 包装为操作任务
-    const task: OperationTask = {
-      id: crypto.randomUUID(),
-      type: OperationType.DELETE,
-      targetSkill: skillName,
-      status: 'pending' as any,
-      execute: async () => {
-        await this.doDeleteSkill(skillName);
-      },
-      createdAt: new Date(),
-    };
-
-    // 入队并等待完成
-    await this.operationQueue.enqueue(task);
-    await this.waitForTask(task);
-
-    // 检查是否有错误
-    if (task.error) {
-      throw task.error;
-    }
-  }
-
-  /**
-   * 恢复已删除的技能
-   * @param archivedSkillName archived中的技能名称（含时间戳）
-   */
-  async restoreSkill(archivedSkillName: string): Promise<void> {
-    // 包装为操作任务
-    const task: OperationTask = {
-      id: crypto.randomUUID(),
-      type: OperationType.RESTORE,
-      targetSkill: archivedSkillName,
-      status: 'pending' as any,
-      execute: async () => {
-        await this.doRestoreSkill(archivedSkillName);
-      },
-      createdAt: new Date(),
-    };
-
-    // 入队并等待完成
-    await this.operationQueue.enqueue(task);
-    await this.waitForTask(task);
-
-    // 检查是否有错误
-    if (task.error) {
-      throw task.error;
-    }
-  }
-
-  /**
-   * 获取技能文件树（仅在线技能）
-   * @param skillName 技能名称
-   */
-  async getSkillFileTree(skillName: string): Promise<SkillFileTree> {
-    // 获取技能信息
-    const skill = await this.skillsManager.loadSkillContent(skillName);
-    if (!skill) {
-      throw new Error(`Skill not found: ${skillName}`);
-    }
-
-    // 验证技能不是archived（排除.archived目录）
-    if (skill.metadata.baseDir.includes('/.archived/') ||
-        skill.metadata.baseDir.includes('\\.archived\\')) {
-      throw new Error(`Cannot get file tree for archived skill: ${skillName}`);
-    }
-
-    // 使用SandboxFileManager获取文件树
-    return await this.sandboxFileManager.listFiles(
-      skill.metadata.baseDir,
-      '.'
-    );
-  }
-
-  /**
-   * 获取队列状态
-   */
-  getQueueStatus() {
-    return this.operationQueue.getQueueStatus();
-  }
-
-  // ==================== 私有方法 ====================
-
-  /**
-   * 执行创建技能
-   */
-  private async doCreateSkill(
-    skillName: string,
-    options: CreateSkillOptions
-  ): Promise<void> {
-    // 1. 验证技能名称
-    if (!this.isValidSkillName(skillName)) {
-      throw new Error(`Invalid skill name: ${skillName}`);
-    }
-
-    // 优先检查archived技能是否已存在（因为 SkillsManager 也会扫描 .archived 目录）
-    const archivedSkills = await this.listArchivedSkills();
-    const archivedSkill = archivedSkills.find(s => s.originalName === skillName);
-    if (archivedSkill) {
-      throw new Error(
-        `Archived skill with name '${skillName}' already exists. Please restore or permanently delete it first.`
-      );
-    }
-
-    // 检查在线技能是否已存在（排除 .archived 目录中的技能）
-    const existingSkill = await this.skillsManager.loadSkillContent(skillName);
-    if (existingSkill) {
-      // 二次验证：确保技能不在 .archived 目录中
-      if (existingSkill.metadata.baseDir.includes('/.archived/') ||
-          existingSkill.metadata.baseDir.includes('\\.archived\\')) {
-        throw new Error(
-          `Archived skill with name '${skillName}' already exists. Please restore or permanently delete it first.`
-        );
+    try {
+      // 1. 验证旧技能存在
+      const oldPath = path.join(this.skillsDir, oldName);
+      const exists = await this.fileExists(oldPath);
+      if (!exists) {
+        throw new Error(`技能不存在: ${oldName}`);
       }
-      throw new Error(`Skill already exists: ${skillName}`);
+
+      // 2. 验证新名称
+      if (!this.isValidSkillName(newName)) {
+        throw new Error(`无效的技能名称: ${newName}`);
+      }
+
+      const newPath = path.join(this.skillsDir, newName);
+      if (await this.fileExists(newPath)) {
+        throw new Error(`技能已存在: ${newName}`);
+      }
+
+      // 3. 重命名目录（仅修改文件夹名称，不修改SKILL.md内容）
+      await this.safeRename(oldPath, newPath);
+
+      logger.log(`[SkillsManagementManager] 技能已重命名: ${oldName} -> ${newName}`);
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error renaming skill:', error);
+      throw error;
     }
-
-    // 2. 创建目录结构
-    const skillDir = path.join(this.skillsDir, skillName);
-    await fs.mkdir(skillDir, { recursive: true });
-    await fs.mkdir(path.join(skillDir, 'references'));
-    await fs.mkdir(path.join(skillDir, 'scripts'));
-    await fs.mkdir(path.join(skillDir, 'assets'));
-
-    // 3. 生成SKILL.md
-    const skillMdContent = this.generateSkillMd(options);
-    await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillMdContent, 'utf-8');
-
-    logger.log(`[SkillsManagementManager] Skill created: ${skillName}`);
   }
 
   /**
-   * 执行重命名技能
+   * 7. 在线技能转归档
+   * @param skillName 技能名称
+   * 归档名称: {原技能名称}-{XXXXXXXX}
    */
-  private async doRenameSkill(oldName: string, newName: string): Promise<void> {
-    // 1. 验证旧技能存在
-    const oldSkill = await this.skillsManager.loadSkillContent(oldName);
-    if (!oldSkill) {
-      throw new Error(`Skill not found: ${oldName}`);
+  async archiveSkill(skillName: string): Promise<void> {
+    try {
+      // 1. 验证技能存在
+      const skillDir = path.join(this.skillsDir, skillName);
+      const exists = await this.fileExists(skillDir);
+      if (!exists) {
+        throw new Error(`技能不存在: ${skillName}`);
+      }
+
+      // 2. 生成8位随机后缀
+      const suffix = await this.generateRandomSuffix();
+      const archivedName = `${skillName}-${suffix}`;
+
+      // 3. 确保.archived目录存在
+      await fs.mkdir(this.archivedDir, { recursive: true });
+
+      // 4. 移动到.archived目录
+      const archivedPath = path.join(this.archivedDir, archivedName);
+      await this.safeRename(skillDir, archivedPath);
+
+      logger.log(`[SkillsManagementManager] 技能已归档: ${skillName} -> ${archivedName}`);
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error archiving skill:', error);
+      throw error;
     }
-
-    // 2. 验证新名称
-    if (!this.isValidSkillName(newName)) {
-      throw new Error(`Invalid skill name: ${newName}`);
-    }
-
-    const newSkill = await this.skillsManager.loadSkillContent(newName);
-    if (newSkill) {
-      throw new Error(`Skill already exists: ${newName}`);
-    }
-
-    // 3. 重命名目录
-    const oldPath = path.join(this.skillsDir, oldName);
-    const newPath = path.join(this.skillsDir, newName);
-    await fs.rename(oldPath, newPath);
-
-    // 4. 更新SKILL.md中的name字段
-    const skillMdPath = path.join(newPath, 'SKILL.md');
-    let content = await fs.readFile(skillMdPath, 'utf-8');
-    content = content.replace(/^name:\s*.+$/m, `name: ${newName}`);
-    await fs.writeFile(skillMdPath, content, 'utf-8');
-
-    logger.log(`[SkillsManagementManager] Skill renamed: ${oldName} -> ${newName}`);
   }
 
   /**
-   * 执行编辑技能文件
+   * 8. 归档技能转在线
+   * @param archivedSkillName archived中的技能名称(含后缀)
+   * 移入前检测重名
    */
-  private async doEditSkillFile(
-    skillName: string,
-    filePath: string,
-    content: string,
-    useSandbox: boolean
-  ): Promise<void> {
-    // 1. 获取技能信息
-    const skill = await this.skillsManager.loadSkillContent(skillName);
-    if (!skill) {
-      throw new Error(`Skill not found: ${skillName}`);
-    }
+  async unarchiveSkill(archivedSkillName: string): Promise<void> {
+    try {
+      // 1. 验证.archived技能存在
+      const archivedPath = path.join(this.archivedDir, archivedSkillName);
+      const exists = await this.fileExists(archivedPath);
+      if (!exists) {
+        throw new Error(`归档技能不存在: ${archivedSkillName}`);
+      }
 
-    // 1.1 验证技能是否为archived（不支持编辑.archived中的技能）
-    if (skill.metadata.baseDir.includes('/.archived/') ||
-        skill.metadata.baseDir.includes('\\.archived\\')) {
-      throw new Error(
-        `Cannot edit archived skill: ${skillName}. Please restore it first.`
-      );
-    }
+      // 2. 提取原始名称(去除-XXXXXXXX后缀)
+      const match = archivedSkillName.match(/^(.+)-[a-f0-9]{8}$/);
+      if (!match) {
+        throw new Error(`无效的归档技能名称: ${archivedSkillName}`);
+      }
+      const originalName = match[1];
 
-    // 2. 验证文件路径（防止路径穿越）
-    const normalizedPath = path.normalize(filePath);
-    if (normalizedPath.startsWith('..') || path.isAbsolute(normalizedPath)) {
-      throw new Error(`Invalid file path: ${filePath}`);
-    }
+      // 3. 检测重名
+      const targetPath = path.join(this.skillsDir, originalName);
+      if (await this.fileExists(targetPath)) {
+        throw new Error(`技能已存在: ${originalName}`);
+      }
 
-    // 3. 写入文件
-    if (useSandbox) {
-      // 使用sandbox写入（安全）
-      await this.sandboxFileManager.writeFile(
-        skill.metadata.baseDir,
-        normalizedPath,
-        content
-      );
-    } else {
-      // 直接写入（不推荐）
-      const fullPath = path.join(skill.metadata.baseDir, normalizedPath);
-      await fs.writeFile(fullPath, content, 'utf-8');
-    }
+      // 4. 移回skills目录
+      await this.safeRename(archivedPath, targetPath);
 
-    logger.log(`[SkillsManagementManager] File edited: ${skillName}/${filePath}`);
+      logger.log(`[SkillsManagementManager] 技能已恢复: ${archivedSkillName} -> ${originalName}`);
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error unarchiving skill:', error);
+      throw error;
+    }
   }
 
   /**
-   * 执行删除技能
+   * 9. 查看在线技能内容
+   * @param skillName 技能名称
+   * 返回SKILL.md完整内容(包含frontmatter和正文)
    */
-  private async doDeleteSkill(skillName: string): Promise<void> {
-    // 1. 验证技能存在
-    const skill = await this.skillsManager.loadSkillContent(skillName);
-    if (!skill) {
-      throw new Error(`Skill not found: ${skillName}`);
+  async getOnlineSkillContent(skillName: string): Promise<string> {
+    try {
+      // 1. 验证技能存在
+      const skillDir = path.join(this.skillsDir, skillName);
+      const exists = await this.fileExists(skillDir);
+      if (!exists) {
+        throw new Error(`技能不存在: ${skillName}`);
+      }
+
+      // 2. 读取SKILL.md
+      const skillMdPath = path.join(skillDir, 'SKILL.md');
+      const skillExists = await this.fileExists(skillMdPath);
+      if (!skillExists) {
+        throw new Error(`SKILL.md不存在: ${skillName}`);
+      }
+
+      // 3. 返回完整内容
+      const content = await fs.readFile(skillMdPath, 'utf-8');
+      return content;
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error getting online skill content:', error);
+      throw error;
     }
-
-    // 2. 确保archived目录存在（使用配置的归档目录）
-    const archivedDir = this.archivedDir;
-    await fs.mkdir(archivedDir, { recursive: true });
-
-    // 3. 生成归档名称
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const archivedName = `${skillName}_${timestamp}`;
-    const archivedPath = path.join(archivedDir, archivedName);
-
-    // 4. 移动到archived
-    await fs.rename(skill.metadata.baseDir, archivedPath);
-
-    logger.log(`[SkillsManagementManager] Skill archived: ${skillName} -> ${archivedName}`);
   }
 
   /**
-   * 执行恢复技能
+   * 10. 查看归档技能内容
+   * @param archivedSkillName 归档技能名称(含8位后缀)
+   * 返回SKILL.md完整内容(包含frontmatter和正文)
    */
-  private async doRestoreSkill(archivedSkillName: string): Promise<void> {
-    // 1. 查找archived技能（使用配置的归档目录）
-    const archivedDir = this.archivedDir;
-    const archivedPath = path.join(archivedDir, archivedSkillName);
+  async getArchivedSkillContent(archivedSkillName: string): Promise<string> {
+    try {
+      // 1. 验证归档技能存在
+      const skillDir = path.join(this.archivedDir, archivedSkillName);
+      const exists = await this.fileExists(skillDir);
+      if (!exists) {
+        throw new Error(`归档技能不存在: ${archivedSkillName}`);
+      }
 
-    const exists = await this.fileExists(archivedPath);
-    if (!exists) {
-      throw new Error(`Archived skill not found: ${archivedSkillName}`);
+      // 2. 读取SKILL.md
+      const skillMdPath = path.join(skillDir, 'SKILL.md');
+      const skillExists = await this.fileExists(skillMdPath);
+      if (!skillExists) {
+        throw new Error(`SKILL.md不存在: ${archivedSkillName}`);
+      }
+
+      // 3. 返回完整内容
+      const content = await fs.readFile(skillMdPath, 'utf-8');
+      return content;
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error getting archived skill content:', error);
+      throw error;
     }
+  }
 
-    // 2. 提取原始名称（去掉时间戳后缀，支持带毫秒和不带毫秒两种格式）
-    const originalName = archivedSkillName.replace(
-      /_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3})?Z$/,
-      ''
-    );
+  /**
+   * 11. 查看在线技能文件目录结构
+   * @param skillName 技能名称
+   * 返回JSON格式的目录树结构
+   */
+  async getOnlineSkillStructure(skillName: string): Promise<object> {
+    try {
+      // 1. 验证技能存在
+      const skillDir = path.join(this.skillsDir, skillName);
+      const exists = await this.fileExists(skillDir);
+      if (!exists) {
+        throw new Error(`技能不存在: ${skillName}`);
+      }
 
-    // 3. 检查目标位置是否已存在
-    const targetPath = path.join(this.skillsDir, originalName);
-    if (await this.fileExists(targetPath)) {
-      throw new Error(`Skill already exists: ${originalName}`);
+      // 2. 构建目录树
+      return await this.buildDirectoryTree(skillDir, skillName);
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error getting online skill structure:', error);
+      throw error;
     }
+  }
 
-    // 4. 移回skills目录
-    await fs.rename(archivedPath, targetPath);
+  /**
+   * 12. 查看归档技能文件目录结构
+   * @param archivedSkillName 归档技能名称(含8位后缀)
+   * 返回JSON格式的目录树结构
+   */
+  async getArchivedSkillStructure(archivedSkillName: string): Promise<object> {
+    try {
+      // 1. 验证归档技能存在
+      const skillDir = path.join(this.archivedDir, archivedSkillName);
+      const exists = await this.fileExists(skillDir);
+      if (!exists) {
+        throw new Error(`归档技能不存在: ${archivedSkillName}`);
+      }
 
-    logger.log(`[SkillsManagementManager] Skill restored: ${archivedSkillName} -> ${originalName}`);
+      // 2. 构建目录树
+      return await this.buildDirectoryTree(skillDir, archivedSkillName);
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error getting archived skill structure:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 13. 导出技能
+   * @param skillName 技能名称(在线或归档)
+   * @param isArchived 是否为归档技能
+   * 使用系统zip命令打包,放入临时目录
+   */
+  async exportSkill(skillName: string, isArchived: boolean): Promise<string> {
+    try {
+      // 1. 确定技能路径
+      let skillDir: string;
+      if (isArchived) {
+        skillDir = path.join(this.archivedDir, skillName);
+      } else {
+        skillDir = path.join(this.skillsDir, skillName);
+      }
+
+      const exists = await this.fileExists(skillDir);
+      if (!exists) {
+        throw new Error(`技能不存在: ${skillName}`);
+      }
+
+      // 2. 生成zip文件路径
+      const zipFileName = `${skillName}.zip`;
+      const zipFilePath = path.join(os.tmpdir(), zipFileName);
+
+      // 3. 使用系统zip命令打包
+      await this.createZip(skillDir, zipFilePath);
+
+      logger.log(`[SkillsManagementManager] 技能已导出: ${skillName} -> ${zipFilePath}`);
+
+      return zipFilePath;
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error exporting skill:', error);
+      throw error;
+    }
+  }
+
+  // ==================== 私有辅助方法 ====================
+
+  /**
+   * 递归构建目录树
+   */
+  private async buildDirectoryTree(dirPath: string, relativePath: string = ''): Promise<object> {
+    try {
+      const stats = await fs.stat(dirPath);
+      const name = path.basename(dirPath);
+
+      if (!stats.isDirectory()) {
+        return {
+          name,
+          type: 'file',
+          path: relativePath || name,
+          size: stats.size,
+          modifiedTime: stats.mtime.toISOString(),
+        };
+      }
+
+      const entries = await fs.readdir(dirPath, { withFileTypes: true });
+      const children: object[] = [];
+
+      for (const entry of entries) {
+        const fullPath = path.join(dirPath, entry.name);
+        const entryRelativePath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
+
+        if (entry.isDirectory()) {
+          children.push(await this.buildDirectoryTree(fullPath, entryRelativePath));
+        } else {
+          const stat = await fs.stat(fullPath);
+          children.push({
+            name: entry.name,
+            type: 'file',
+            path: entryRelativePath,
+            size: stat.size,
+            modifiedTime: stat.mtime.toISOString(),
+          });
+        }
+      }
+
+      return {
+        name,
+        type: 'directory',
+        path: relativePath || name,
+        children,
+      };
+    } catch (error: any) {
+      logger.error('[SkillsManagementManager] Error building directory tree:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 解析SKILL.md的YAML frontmatter
+   */
+  private parseSkillMd(content: string): any {
+    const match = content.match(/^---\n([\s\S]+?)\n---/);
+    if (!match) return null;
+
+    const yamlContent = match[1];
+    // 简单YAML解析(只解析基本字段)
+    const nameMatch = yamlContent.match(/^name:\s*(.+)$/m);
+    const descMatch = yamlContent.match(/^description:\s*(.+)$/m);
+    const licenseMatch = yamlContent.match(/^license:\s*(.+)$/m);
+
+    if (!nameMatch) return null;
+
+    return {
+      name: nameMatch[1].trim(),
+      description: descMatch ? descMatch[1].trim() : '',
+      license: licenseMatch ? licenseMatch[1].trim() : undefined,
+    };
+  }
+
+  /**
+   * 验证SKILL.md格式(遵循Specification.md规范)
+   */
+  private async validateSkillMd(skillMdPath: string): Promise<boolean> {
+    const exists = await this.fileExists(skillMdPath);
+    if (!exists) return false;
+
+    const content = await fs.readFile(skillMdPath, 'utf-8');
+    const metadata = this.parseSkillMd(content);
+    if (!metadata) return false;
+
+    // 验证必需字段
+    if (!metadata.name || !metadata.description) return false;
+
+    // 验证name字段格式(1-64字符,小写字母数字和连字符)
+    const nameRegex = /^[a-z0-9-]{1,64}$/;
+    if (!nameRegex.test(metadata.name)) return false;
+
+    // 验证name不以连字符开头或结尾
+    if (metadata.name.startsWith('-') || metadata.name.endsWith('-')) return false;
+
+    return true;
+  }
+
+  /**
+   * 生成8位随机后缀
+   * 规则: uuidv4 → sha256 → 全小写 → 取前8位
+   */
+  private async generateRandomSuffix(): Promise<string> {
+    // 1. 生成UUID v4
+    const uuid = crypto.randomUUID();
+
+    // 2. 计算SHA256
+    const hash = crypto.createHash('sha256').update(uuid).digest('hex');
+
+    // 3. 全小写并取前8位
+    return hash.toLowerCase().substring(0, 8);
   }
 
   /**
    * 验证技能名称
    */
   private isValidSkillName(name: string): boolean {
-    // 只允许字母、数字、连字符、下划线
-    return /^[a-zA-Z0-9_-]+$/.test(name) && name.length > 0 && name.length <= 50;
-  }
-
-  /**
-   * 生成SKILL.md内容
-   */
-  private generateSkillMd(options: CreateSkillOptions): string {
-    const { name, description = '' } = options;
-
-    return `---
-name: ${name}
-description: ${description}
----
-
-# ${name}
-
-This is a custom skill created for ${name}.
-
-## Usage
-
-Describe how to use this skill here.
-
-## Configuration
-
-Add any configuration details here.
-`;
+    // 只允许小写字母、数字、连字符
+    const nameRegex = /^[a-z0-9-]+$/;
+    return nameRegex.test(name) &&
+           name.length > 0 &&
+           name.length <= 64 &&
+           !name.startsWith('-') &&
+           !name.endsWith('-') &&
+           !name.includes('--');
   }
 
   /**
@@ -627,25 +815,68 @@ Add any configuration details here.
   }
 
   /**
-   * 等待任务完成
+   * 解压zip文件
    */
-  private async waitForTask(task: OperationTask): Promise<void> {
-    // 轮询任务状态，最多等待30秒
-    const maxWaitTime = 30000;
-    const pollInterval = 100;
-    let totalWaited = 0;
+  private async extractZip(zipFilePath: string, targetDir: string): Promise<void> {
+    const platform = os.platform();
 
-    while (
-      task.status !== 'completed' &&
-      task.status !== 'failed' &&
-      totalWaited < maxWaitTime
-    ) {
-      await new Promise(resolve => setTimeout(resolve, pollInterval));
-      totalWaited += pollInterval;
+    try {
+      let cmd: string;
+      if (platform === 'win32') {
+        // Windows: 使用tar命令(Windows 10+内置)
+        cmd = `tar -xf "${zipFilePath}" -C "${targetDir}"`;
+      } else {
+        // Linux/Mac: 使用unzip命令
+        cmd = `unzip -q "${zipFilePath}" -d "${targetDir}"`;
+      }
+
+      await execAsync(cmd);
+    } catch (error: any) {
+      throw new Error(`解压失败: ${error.message}`);
     }
+  }
 
-    if (task.status !== 'completed' && task.status !== 'failed') {
-      throw new Error(`Operation timeout: ${task.type} - ${task.targetSkill}`);
+  /**
+   * 跨平台的安全重命名方法
+   * Windows上使用"复制-删除"方式避免EPERM错误
+   */
+  private async safeRename(oldPath: string, newPath: string): Promise<void> {
+    const platform = os.platform();
+
+    try {
+      if (platform === 'win32') {
+        // Windows: 使用复制-删除方式（更可靠）
+        await fs.cp(oldPath, newPath, { recursive: true });
+        await fs.rm(oldPath, { recursive: true, force: true });
+      } else {
+        // Unix-like系统: 直接使用rename
+        await fs.rename(oldPath, newPath);
+      }
+    } catch (error: any) {
+      logger.error(`[SkillsManagementManager] safeRename failed: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * 创建zip文件
+   */
+  private async createZip(sourceDir: string, zipFilePath: string): Promise<void> {
+    const platform = os.platform();
+
+    try {
+      let cmd: string;
+      if (platform === 'win32') {
+        // Windows: 使用PowerShell的Compress-Archive
+        cmd = `powershell -Command "Compress-Archive -Path '${sourceDir}\\*' -DestinationPath '${zipFilePath}' -Force"`;
+      } else {
+        // Linux/Mac: 使用zip命令
+        cmd = `cd "${sourceDir}" && zip -r "${zipFilePath}" .`;
+      }
+
+      await execAsync(cmd);
+    } catch (error: any) {
+      throw new Error(`创建zip失败: ${error.message}`);
     }
   }
 }

--- a/src/core/skills/types.ts
+++ b/src/core/skills/types.ts
@@ -63,6 +63,8 @@ export interface SkillInfo {
   path: string;
   /** 技能根目录 */
   baseDir: string;
+  /** 文件夹名称（技能目录名） */
+  folderName: string;
   /** 创建时间 */
   createdAt?: string;
   /** 更新时间 */
@@ -123,6 +125,16 @@ export interface ArchivedSkillInfo {
   archivedName: string;
   /** archived目录中的完整路径 */
   archivedPath: string;
+  /** 文件夹名称（归档目录名） */
+  folderName: string;
   /** 归档时间 */
   archivedAt: string;
+  /** 技能名称（从SKILL.md解析） */
+  name?: string;
+  /** 技能描述（从SKILL.md解析） */
+  description?: string;
+  /** 许可证（从SKILL.md解析） */
+  license?: string;
+  /** 其他元数据 */
+  metadata?: Record<string, string>;
 }

--- a/src/tools/skills.ts
+++ b/src/tools/skills.ts
@@ -55,11 +55,11 @@ export function createSkillsTool(skillsManager: SkillsManager) {
 
       // 注释掉 list 操作的代码
       // if (action === 'list') {
-      //   // 列出所有skills
+      //   // 列出所有skills（使用文件夹名称作为标识符）
       //   const skills = await skillsManager.getSkillsMetadata();
       //
       //   const skillsList = skills.map(s => ({
-      //     name: s.name,
+      //     name: s.name,  // 文件夹名称
       //     description: s.description,
       //   }));
       //

--- a/tests/integration/agent/mcp-agent.test.ts
+++ b/tests/integration/agent/mcp-agent.test.ts
@@ -1,0 +1,334 @@
+/**
+ * MCP 工具与 Agent 集成测试
+ *
+ * 测试 MCP 工具在真实 Agent 场景中的使用
+ * 验证：
+ * - MCP 工具与 Agent 的集成
+ * - 工具命名空间在 Agent 中的正确识别
+ * - 工具注册和可用性
+ */
+
+import path from 'path';
+import {
+  Agent,
+  getMCPTools,
+  disconnectAllMCP,
+  MCPConfig,
+  ToolRegistry,
+  builtin,
+  AnthropicProvider,
+  JSONStore,
+  AgentTemplateRegistry,
+  SandboxFactory,
+} from '../../../src';
+import { createIntegrationTestAgent } from '../../helpers/setup';
+import { TestRunner, expect } from '../../helpers/utils';
+
+const runner = new TestRunner('集成测试 - MCP 工具与 Agent 集成');
+
+/**
+ * 辅助函数：带超时的 Promise 包装
+ */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  errorMessage: string = '操作超时'
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutHandle!);
+  }
+}
+
+/**
+ * 测试 1: MCP 工具注册到 Agent
+ */
+runner.test('MCP 工具注册到 Agent 工具注册表', async () => {
+  // 连接 MCP 服务器
+  const mcpConfig: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'registry-time',
+  };
+
+  const mcpTools = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '连接 MCP 服务器超时'
+  );
+
+  expect.toBeGreaterThan(mcpTools.length, 0, '应获取到 MCP 工具');
+
+  // 验证工具结构
+  const firstTool = mcpTools[0];
+  expect.toBeTruthy(firstTool.name, '工具应有名称');
+  expect.toBeTruthy(firstTool.description, '工具应有描述');
+  expect.toBeTruthy(firstTool.exec, '工具应有 exec 方法');
+  expect.toContain(firstTool.name, 'mcp__registry-time__', '工具名应包含命名空间');
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 2: MCP 工具可以直接调用
+ */
+runner.test('MCP 工具可以直接调用', async () => {
+  // 连接 MCP 服务器
+  const mcpConfig: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'direct-call',
+  };
+
+  const mcpTools = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '连接 MCP 服务器超时'
+  );
+
+  // 直接调用工具（不通过 Agent）
+  const timeTool = mcpTools.find(t => t.name.includes('time'));
+
+  if (timeTool) {
+    const result = await withTimeout(
+      timeTool.exec({ timezone: 'Asia/Shanghai' }, {} as any),
+      10000,
+      '工具调用超时'
+    );
+
+    expect.toBeTruthy(result, '应返回结果');
+    expect.toBeTruthy(result.content, '应返回内容');
+  } else {
+    console.log('  ⚠️  未找到时间工具，跳过直接调用测试');
+  }
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 3: Agent 注册 MCP 工具
+ */
+runner.test('Agent 成功注册 MCP 工具', async () => {
+  // 连接 MCP 服务器
+  const mcpConfig: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'agent-register',
+  };
+
+  const mcpTools = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '连接 MCP 服务器超时'
+  );
+
+  expect.toBeGreaterThan(mcpTools.length, 0, '应获取到 MCP 工具');
+
+  // 验证工具已注册（通过创建 ToolRegistry）
+  const registry = new ToolRegistry();
+  for (const tool of mcpTools) {
+    registry.register(tool.name, () => tool);
+  }
+
+  // 验证工具已注册
+  for (const tool of mcpTools) {
+    const hasTool = registry.has(tool.name);
+    expect.toBeTruthy(hasTool, `工具 ${tool.name} 应已注册`);
+  }
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 4: 多个 MCP 服务器工具集成
+ */
+runner.test('多个 MCP 服务器工具集成', async () => {
+  // 连接多个 MCP 服务器
+  const mcpConfigs: MCPConfig[] = [
+    {
+      transport: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-time'],
+      serverName: 'multi-1',
+    },
+    {
+      transport: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-time'],
+      serverName: 'multi-2',
+    },
+  ];
+
+  const allMcpTools = await Promise.all(
+    mcpConfigs.map(config =>
+      withTimeout(getMCPTools(config), 30000, '连接 MCP 服务器超时')
+    )
+  );
+
+  const mcpTools = allMcpTools.flat();
+
+  // 验证工具来自不同命名空间
+  const server1Tools = mcpTools.filter(t => t.name.includes('mcp__multi-1__'));
+  const server2Tools = mcpTools.filter(t => t.name.includes('mcp__multi-2__'));
+
+  expect.toBeGreaterThan(server1Tools.length, 0, '应有来自服务器 1 的工具');
+  expect.toBeGreaterThan(server2Tools.length, 0, '应有来自服务器 2 的工具');
+
+  // 验证命名空间隔离
+  const allNames = new Set(mcpTools.map(t => t.name));
+  expect.toEqual(allNames.size, mcpTools.length, '工具名应唯一（命名空间隔离）');
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 5: MCP 工具白名单/黑名单过滤
+ */
+runner.test('MCP 工具过滤功能', async () => {
+  // 连接 MCP 服务器并使用白名单
+  const mcpConfig: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'filter-test',
+    include: ['get_current_time'], // 白名单
+  };
+
+  const mcpTools = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '连接 MCP 服务器超时'
+  );
+
+  // 验证只返回了白名单中的工具
+  for (const tool of mcpTools) {
+    expect.toContain(tool.name, 'get_current_time', '工具名应包含白名单中的名称');
+  }
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 6: MCP 工具与 LLM 集成测试（简化版）
+ */
+runner.test('MCP 工具输入模式验证', async () => {
+  // 连接 MCP 服务器
+  const mcpConfig: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'schema-test',
+  };
+
+  const mcpTools = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '连接 MCP 服务器超时'
+  );
+
+  // 验证工具的 input_schema 适合 LLM 使用
+  for (const tool of mcpTools) {
+    expect.toBeTruthy(tool.input_schema, `工具 ${tool.name} 应有 input_schema`);
+    expect.toBeTruthy(typeof tool.input_schema === 'object', 'input_schema 应是对象');
+
+    // 验证 input_schema 包含必要的字段
+    const schema = tool.input_schema;
+    expect.toBeTruthy(schema.type || schema.$schema, 'schema 应有 type 或 $schema 字段');
+  }
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 7: MCP 工具描述符信息
+ */
+runner.test('MCP 工具描述符包含完整元数据', async () => {
+  // 连接 MCP 服务器
+  const mcpConfig: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'descriptor-test',
+  };
+
+  const mcpTools = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '连接 MCP 服务器超时'
+  );
+
+  // 验证工具描述符
+  for (const tool of mcpTools) {
+    const descriptor = tool.toDescriptor();
+
+    expect.toEqual(descriptor.source, 'mcp', '工具来源应为 mcp');
+    expect.toBeTruthy(descriptor.name, '描述符应有名称');
+    expect.toBeTruthy(descriptor.metadata, '描述符应有元数据');
+    expect.toEqual(descriptor.metadata?.mcpServer, 'descriptor-test', '应记录 MCP 服务器名');
+    expect.toEqual(descriptor.metadata?.transport, 'stdio', '应记录传输类型');
+  }
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 8: MCP 断开重连
+ */
+runner.test('MCP 断开连接后重新连接', async () => {
+  const serverName = 'reconnect-test';
+  const mcpConfig: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName,
+  };
+
+  // 第一次连接
+  const tools1 = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '第一次连接超时'
+  );
+  expect.toBeGreaterThan(tools1.length, 0, '第一次连接应返回工具');
+
+  // 断开连接
+  await disconnectAllMCP();
+
+  // 重新连接
+  const tools2 = await withTimeout(
+    getMCPTools(mcpConfig),
+    30000,
+    '重新连接超时'
+  );
+  expect.toBeGreaterThan(tools2.length, 0, '重新连接应返回工具');
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+export async function run() {
+  return await runner.run();
+}
+
+if (require.main === module) {
+  run().catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/tests/integration/tools/mcp.test.ts
+++ b/tests/integration/tools/mcp.test.ts
@@ -1,0 +1,571 @@
+/**
+ * MCP 工具集成测试
+ *
+ * 测试 MCP (Model Context Protocol) 工具的接入和功能
+ * 包括：
+ * - stdio 传输方式的连接
+ * - 工具注册和调用
+ * - 多服务器管理
+ * - 工具命名空间化
+ * - 连接断开和清理
+ */
+
+import path from 'path';
+import {
+  getMCPTools,
+  disconnectMCP,
+  disconnectAllMCP,
+  MCPConfig,
+  ToolRegistry,
+} from '../../../src';
+import { TestRunner, expect, retry } from '../../helpers/utils';
+
+const runner = new TestRunner('集成测试 - MCP 工具接入');
+
+// 测试超时时间（毫秒）
+const TEST_TIMEOUT = 60000;
+
+/**
+ * 辅助函数：带超时的测试执行
+ */
+async function withTimeout<T>(
+  fn: () => Promise<T>,
+  timeoutMs: number,
+  errorMessage: string = '操作超时'
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([fn(), timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutHandle!);
+  }
+}
+
+/**
+ * 测试 1: 连接 mcp-server-time (uvx)
+ */
+runner.test('连接 mcp-server-time 服务器 (uvx stdio)', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'time',
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT,
+    '连接 mcp-server-time 超时，请确保已安装 uvx 命令'
+  );
+
+  // 验证返回了工具
+  expect.toBeGreaterThan(tools.length, 0, '应该至少返回一个工具');
+
+  // 验证工具命名空间化
+  const firstTool = tools[0];
+  expect.toContain(firstTool.name, 'mcp__time__', '工具名应包含命名空间前缀');
+
+  // 验证工具描述
+  expect.toBeTruthy(firstTool.description, '工具应有描述信息');
+
+  // 验证工具 descriptor
+  const descriptor = firstTool.toDescriptor();
+  expect.toEqual(descriptor.source, 'mcp', '工具来源应为 mcp');
+  expect.toEqual(descriptor.metadata?.mcpServer, 'time', '应记录 MCP 服务器名称');
+
+  // 清理连接
+  await disconnectMCP('time');
+});
+
+/**
+ * 测试 2: 连接 @tokenizin/mcp-npx-fetch (npx)
+ */
+runner.test('连接 @tokenizin/mcp-npx-fetch 服务器 (npx stdio)', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@tokenizin/mcp-npx-fetch'],
+    serverName: 'fetch',
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT,
+    '连接 @tokenizin/mcp-npx-fetch 超时，请确保网络连接正常'
+  );
+
+  // 验证返回了工具
+  expect.toBeGreaterThan(tools.length, 0, '应该至少返回一个工具');
+
+  // 验证工具命名空间化
+  const fetchTool = tools.find(t => t.name.includes('fetch'));
+  expect.toBeTruthy(fetchTool, '应该找到包含 fetch 的工具');
+
+  // 验证工具结构
+  expect.toBeTruthy(fetchTool!.input_schema, '工具应有输入模式定义');
+  expect.toBeTruthy(typeof fetchTool!.exec === 'function', '工具应有 exec 方法');
+
+  // 清理连接
+  await disconnectMCP('fetch');
+});
+
+/**
+ * 测试 3: 工具白名单过滤
+ */
+runner.test('工具白名单过滤功能', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'time-filter',
+    include: ['get_current_time'], // 只包含特定工具
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 验证只返回了白名单中的工具
+  expect.toEqual(tools.length, 1, '应该只返回一个工具（白名单过滤）');
+
+  // 验证工具名
+  expect.toEqual(tools[0].name, 'mcp__time-filter__get_current_time', '工具名应匹配白名单');
+
+  // 清理连接
+  await disconnectMCP('time-filter');
+});
+
+/**
+ * 测试 4: 工具黑名单过滤
+ */
+runner.test('工具黑名单过滤功能', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'time-exclude',
+    exclude: ['get_current_time'], // 排除特定工具
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 验证没有返回黑名单中的工具
+  const excludedTool = tools.find(t => t.name.includes('get_current_time'));
+  expect.toBeFalsy(excludedTool, '不应该返回被排除的工具');
+
+  // 清理连接
+  await disconnectMCP('time-exclude');
+});
+
+/**
+ * 测试 5: 工具注册到 ToolRegistry
+ */
+runner.test('工具注册到 ToolRegistry', async () => {
+  const registry = new ToolRegistry();
+
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'time-registry',
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 手动注册到自定义 registry
+  for (const tool of tools) {
+    registry.register(tool.name, () => tool);
+  }
+
+  // 验证工具已注册
+  for (const tool of tools) {
+    const hasTool = registry.has(tool.name);
+    expect.toBeTruthy(hasTool, `工具 ${tool.name} 应该已注册`);
+
+    const registered = registry.create(tool.name);
+    expect.toEqual(registered.name, tool.name, '注册的工具名应匹配');
+  }
+
+  // 清理连接
+  await disconnectMCP('time-registry');
+});
+
+/**
+ * 测试 6: 同时连接多个 MCP 服务器
+ */
+runner.test('同时连接多个 MCP 服务器', async () => {
+  const configs: MCPConfig[] = [
+    {
+      transport: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-time'],
+      serverName: 'multi-time',
+    },
+    {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@tokenizin/mcp-npx-fetch'],
+      serverName: 'multi-fetch',
+    },
+  ];
+
+  // 连接所有服务器
+  const allTools = await withTimeout(
+    async () => {
+      const toolsArray = await Promise.all(
+        configs.map(config => getMCPTools(config))
+      );
+      return toolsArray.flat();
+    },
+    TEST_TIMEOUT * 2,
+    '连接多个 MCP 服务器超时'
+  );
+
+  // 验证所有工具都已加载
+  expect.toBeGreaterThan(allTools.length, 0, '应该返回多个工具');
+
+  // 验证不同服务器的工具有不同的命名空间
+  const timeTools = allTools.filter(t => t.name.includes('mcp__multi-time__'));
+  const fetchTools = allTools.filter(t => t.name.includes('mcp__multi-fetch__'));
+
+  expect.toBeGreaterThan(timeTools.length, 0, '应该有来自 time 服务器的工具');
+  expect.toBeGreaterThan(fetchTools.length, 0, '应该有来自 fetch 服务器的工具');
+
+  // 验证命名空间隔离
+  const timeToolNames = new Set(timeTools.map(t => t.name));
+  const fetchToolNames = new Set(fetchTools.map(t => t.name));
+  const hasIntersection = Array.from(timeToolNames).some(name => fetchToolNames.has(name));
+  expect.toBeFalsy(hasIntersection, '不同服务器的工具名不应冲突');
+
+  // 清理所有连接
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 7: 重复连接同一服务器返回缓存连接
+ */
+runner.test('重复连接同一服务器返回缓存', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'cached-time',
+  };
+
+  // 第一次连接
+  const tools1 = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 第二次连接（应该返回缓存）
+  const tools2 = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 验证返回相同的工具
+  expect.toEqual(tools1.length, tools2.length, '两次连接应返回相同数量的工具');
+  expect.toEqual(tools1[0].name, tools2[0].name, '工具名应相同');
+
+  // 清理连接
+  await disconnectMCP('cached-time');
+});
+
+/**
+ * 测试 8: 工具执行（实际调用 MCP 工具）
+ */
+runner.test('工具执行 - 调用 MCP 工具', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'exec-time',
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 找到 get_current_time 工具
+  const timeTool = tools.find(t => t.name.includes('get_current_time'));
+  expect.toBeTruthy(timeTool, '应该找到 get_current_time 工具');
+
+  // 执行工具（不需要参数）
+  const result = await withTimeout(
+    () => timeTool!.exec({}, {} as any),
+    TEST_TIMEOUT
+  );
+
+  // 验证结果
+  expect.toBeTruthy(result, '应该返回结果');
+
+  // 输出详细结果以便调试
+  if (result.isError) {
+    console.log('  ⚠️  工具执行返回 isError，结果:', JSON.stringify(result, null, 2));
+  }
+
+  // 注意：某些 MCP 服务器可能返回 isError=true 但仍包含有效内容
+  // 我们主要验证返回了内容
+  expect.toBeTruthy(result.content, '应返回内容');
+
+  // 清理连接
+  await disconnectMCP('exec-time');
+});
+
+/**
+ * 测试 9: 错误处理 - 缺少必需的 command 参数
+ */
+runner.test('错误处理 - stdio 传输缺少 command', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    serverName: 'error-test',
+  };
+
+  try {
+    await getMCPTools(config);
+    throw new Error('应该抛出错误');
+  } catch (error: any) {
+    expect.toContain(error.message, 'command', '错误信息应包含 command');
+  }
+});
+
+/**
+ * 测试 10: 错误处理 - 无效的命令
+ */
+runner.test('错误处理 - 无效的命令', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'nonexistent-command-xyz-123',
+    args: ['--invalid'],
+    serverName: 'invalid-cmd',
+  };
+
+  let hadError = false;
+  try {
+    await withTimeout(
+      () => getMCPTools(config),
+      15000, // 15 秒超时
+      '无效命令应该在短时间内失败'
+    );
+  } catch (error: any) {
+    hadError = true;
+
+    // 验证是超时或者命令执行错误（支持中英文错误信息和 MCP 错误）
+    const errorMessage = error.message || error.toString() || '';
+    const isValidError =
+      errorMessage.includes('超时') ||
+      errorMessage.includes('ENOENT') ||
+      errorMessage.includes('command not found') ||
+      errorMessage.includes('不是内部或外部命令') ||
+      errorMessage.includes('无法识别') ||
+      errorMessage.includes('not found') ||
+      errorMessage.includes('可执行文件') ||
+      errorMessage.includes('MCP error') ||
+      errorMessage.includes('Connection closed') ||
+      errorMessage.includes('Connection');
+
+    expect.toBeTruthy(isValidError, `应该是命令执行错误或超时，实际错误: ${errorMessage}`);
+  }
+
+  expect.toBeTruthy(hadError, '应该抛出错误');
+
+  // 清理：断开可能已建立的连接
+  try {
+    await disconnectMCP('invalid-cmd');
+  } catch {
+    // 忽略清理错误
+  }
+});
+
+/**
+ * 测试 11: 断开连接后重新连接
+ */
+runner.test('断开连接后重新连接', async () => {
+  const serverName = 'reconnect-time';
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName,
+  };
+
+  // 第一次连接
+  const tools1 = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+  expect.toBeGreaterThan(tools1.length, 0, '第一次连接应返回工具');
+
+  // 断开连接
+  await disconnectMCP(serverName);
+
+  // 重新连接
+  const tools2 = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+  expect.toBeGreaterThan(tools2.length, 0, '重新连接应返回工具');
+
+  // 验证工具一致性
+  expect.toEqual(tools1[0].name, tools2[0].name, '重新连接后工具名应相同');
+
+  // 清理连接
+  await disconnectMCP(serverName);
+});
+
+/**
+ * 测试 12: 工具输入模式验证
+ */
+runner.test('工具输入模式验证', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@tokenizin/mcp-npx-fetch'],
+    serverName: 'schema-test',
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 验证每个工具都有 input_schema
+  for (const tool of tools) {
+    expect.toBeTruthy(tool.input_schema, `工具 ${tool.name} 应有 input_schema`);
+    expect.toBeTruthy(typeof tool.input_schema === 'object', 'input_schema 应是对象');
+  }
+
+  // 清理连接
+  await disconnectMCP('schema-test');
+});
+
+/**
+ * 测试 13: 断开所有连接
+ */
+runner.test('断开所有 MCP 连接', async () => {
+  const configs: MCPConfig[] = [
+    {
+      transport: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-time'],
+      serverName: 'all-1',
+    },
+    {
+      transport: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-time'],
+      serverName: 'all-2',
+    },
+  ];
+
+  // 连接多个服务器
+  await Promise.all(configs.map(config => getMCPTools(config)));
+
+  // 断开所有连接
+  await disconnectAllMCP();
+
+  // 验证：重新连接应该成功（说明之前的连接已清理）
+  const tools = await withTimeout(
+    () => getMCPTools(configs[0]),
+    TEST_TIMEOUT
+  );
+  expect.toBeGreaterThan(tools.length, 0, '断开所有后应能重新连接');
+
+  // 清理
+  await disconnectAllMCP();
+});
+
+/**
+ * 测试 14: 空参数工具调用
+ */
+runner.test('空参数工具调用', async () => {
+  const config: MCPConfig = {
+    transport: 'stdio',
+    command: 'uvx',
+    args: ['mcp-server-time'],
+    serverName: 'no-args',
+  };
+
+  const tools = await withTimeout(
+    () => getMCPTools(config),
+    TEST_TIMEOUT
+  );
+
+  // 调用工具（传递空对象）
+  const result = await withTimeout(
+    () => tools[0].exec({}, {} as any),
+    TEST_TIMEOUT
+  );
+
+  expect.toBeTruthy(result, '应返回结果');
+
+  // 输出详细结果以便调试
+  if (result.isError) {
+    console.log('  ⚠️  工具执行返回 isError，结果:', JSON.stringify(result, null, 2));
+  }
+
+  // 主要验证返回了内容
+  expect.toBeTruthy(result.content, '应返回内容');
+
+  // 清理连接
+  await disconnectMCP('no-args');
+});
+
+/**
+ * 测试 15: 命名空间唯一性
+ */
+runner.test('工具命名空间唯一性', async () => {
+  const configs: MCPConfig[] = [
+    {
+      transport: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-time'],
+      serverName: 'namespace-a',
+    },
+    {
+      transport: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-time'],
+      serverName: 'namespace-b',
+    },
+  ];
+
+  const [toolsA, toolsB] = await Promise.all(
+    configs.map(config => withTimeout(() => getMCPTools(config), TEST_TIMEOUT))
+  );
+
+  // 验证不同服务器的同名工具有不同的命名空间
+  const toolA = toolsA[0];
+  const toolB = toolsB[0];
+
+  expect.toEqual(toolA.name !== toolB.name, true, '不同服务器的工具名应不同');
+  expect.toContain(toolA.name, 'mcp__namespace-a__', '应包含服务器 A 的命名空间');
+  expect.toContain(toolB.name, 'mcp__namespace-b__', '应包含服务器 B 的命名空间');
+
+  // 清理连接
+  await disconnectAllMCP();
+});
+
+export async function run() {
+  return await runner.run();
+}
+
+if (require.main === module) {
+  run().catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/tests/skills/management-manager.test.ts
+++ b/tests/skills/management-manager.test.ts
@@ -1,0 +1,608 @@
+/**
+ * SkillsManagementManager 单元测试
+ *
+ * 测试覆盖:
+ * - 13个核心管理操作
+ * - 边界情况处理
+ * - 错误处理
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { SkillsManagementManager } from '../../src/core/skills/management-manager';
+import { TestRunner, expect } from '../helpers/utils';
+
+const runner = new TestRunner('SkillsManagementManager');
+
+// 测试用的SKILL.md内容
+const validSkillMd = `---
+name: test-skill
+description: A test skill
+---
+
+# Test Skill
+
+This is a test skill.`;
+
+const invalidSkillMd = `---
+name: INVALID-Name
+description: Test
+---
+`;
+
+// 测试环境设置
+let testSkillsDir: string;
+let testArchivedDir: string;
+let manager: SkillsManagementManager;
+
+async function setupTestEnv() {
+  testSkillsDir = path.join(os.tmpdir(), `test-skills-${Date.now()}`);
+  testArchivedDir = path.join(testSkillsDir, '.archived');
+
+  await fs.mkdir(testSkillsDir, { recursive: true });
+  await fs.mkdir(testArchivedDir, { recursive: true });
+
+  manager = new SkillsManagementManager(testSkillsDir, testArchivedDir);
+}
+
+async function cleanupTestEnv() {
+  await fs.rm(testSkillsDir, { recursive: true, force: true });
+}
+
+async function clearTestDirs() {
+  const entries = await fs.readdir(testSkillsDir);
+  for (const entry of entries) {
+    if (entry === '.archived') continue;
+    const fullPath = path.join(testSkillsDir, entry);
+    await fs.rm(fullPath, { recursive: true, force: true });
+  }
+
+  const archivedEntries = await fs.readdir(testArchivedDir);
+  for (const entry of archivedEntries) {
+    const fullPath = path.join(testArchivedDir, entry);
+    await fs.rm(fullPath, { recursive: true, force: true });
+  }
+}
+
+// ==================== 测试用例 ====================
+
+runner
+  .test('1. listSkills - 返回空列表(无技能时)', async () => {
+    await setupTestEnv();
+    try {
+      const skills = await manager.listSkills();
+      expect.toEqual(skills.length, 0);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('1. listSkills - 正确列出在线技能', async () => {
+    await setupTestEnv();
+    try {
+      // 创建测试技能
+      const skillDir = path.join(testSkillsDir, 'test-skill');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 创建archived目录中的技能(应被过滤)
+      const archivedDir = path.join(testArchivedDir, 'archived-skill-a1b2c3d4');
+      await fs.mkdir(archivedDir, { recursive: true });
+      await fs.writeFile(path.join(archivedDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      const skills = await manager.listSkills();
+
+      expect.toEqual(skills.length, 1);
+      expect.toEqual(skills[0].name, 'test-skill');
+      expect.toEqual(skills[0].description, 'A test skill');
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('1. listSkills - 跳过无效的SKILL.md', async () => {
+    await setupTestEnv();
+    try {
+      // 创建无效技能
+      const skillDir = path.join(testSkillsDir, 'invalid-skill');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), 'invalid content', 'utf-8');
+
+      const skills = await manager.listSkills();
+      expect.toEqual(skills.length, 0);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('2. listArchivedSkills - 返回空列表(无归档技能时)', async () => {
+    await setupTestEnv();
+    try {
+      const skills = await manager.listArchivedSkills();
+      expect.toEqual(skills.length, 0);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('2. listArchivedSkills - 正确解析归档技能名称', async () => {
+    await setupTestEnv();
+    try {
+      // 创建归档技能
+      const archivedDir = path.join(testArchivedDir, 'original-skill-a1b2c3d4');
+      await fs.mkdir(archivedDir, { recursive: true });
+      await fs.writeFile(path.join(archivedDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      const skills = await manager.listArchivedSkills();
+
+      expect.toEqual(skills.length, 1);
+      expect.toEqual(skills[0].originalName, 'original-skill');
+      expect.toEqual(skills[0].archivedName, 'original-skill-a1b2c3d4');
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('3. importSkill - zip文件不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.importSkill('/nonexistent/file.zip');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, 'Zip文件不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('4. copySkill - 成功复制技能并生成8位随机后缀', async () => {
+    await setupTestEnv();
+    try {
+      // 创建源技能
+      const sourceDir = path.join(testSkillsDir, 'source-skill');
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 复制技能
+      const newSkillName = await manager.copySkill('source-skill');
+
+      // 验证格式: source-skill-XXXXXXXX
+      expect.toBeTruthy(newSkillName.match(/^source-skill-[a-f0-9]{8}$/));
+
+      // 验证文件存在
+      const newDir = path.join(testSkillsDir, newSkillName);
+      try {
+        await fs.access(newDir);
+        expect.toBeTruthy(true);
+      } catch {
+        expect.toBeTruthy(false); // 文件不存在
+      }
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('4. copySkill - 技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.copySkill('nonexistent-skill');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('5. renameSkill - 成功重命名技能', async () => {
+    await setupTestEnv();
+    try {
+      // 创建源技能
+      const sourceDir = path.join(testSkillsDir, 'old-name');
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 重命名
+      await manager.renameSkill('old-name', 'new-name');
+
+      // 验证旧目录不存在
+      try {
+        await fs.access(sourceDir);
+        expect.toBeTruthy(false); // 不应该执行到这里
+      } catch {
+        expect.toBeTruthy(true); // 目录不存在,符合预期
+      }
+
+      // 验证新目录存在
+      const newDir = path.join(testSkillsDir, 'new-name');
+      await fs.access(newDir);
+
+      // 验证SKILL.md中的name字段已更新
+      const content = await fs.readFile(path.join(newDir, 'SKILL.md'), 'utf-8');
+      expect.toBeTruthy(content.match(/^name: new-name$/m));
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('5. renameSkill - 技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.renameSkill('nonexistent', 'new-name');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('5. renameSkill - 目标名称已存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      // 创建两个技能
+      const dir1 = path.join(testSkillsDir, 'skill1');
+      const dir2 = path.join(testSkillsDir, 'skill2');
+      await fs.mkdir(dir1, { recursive: true });
+      await fs.mkdir(dir2, { recursive: true });
+      await fs.writeFile(path.join(dir1, 'SKILL.md'), validSkillMd, 'utf-8');
+      await fs.writeFile(path.join(dir2, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      let hasError = false;
+      try {
+        await manager.renameSkill('skill1', 'skill2');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能已存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('6. archiveSkill - 成功归档技能并生成8位随机后缀', async () => {
+    await setupTestEnv();
+    try {
+      // 创建技能
+      const skillDir = path.join(testSkillsDir, 'to-archive');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 归档
+      await manager.archiveSkill('to-archive');
+
+      // 验证原目录不存在
+      try {
+        await fs.access(skillDir);
+        expect.toBeTruthy(false); // 不应该执行到这里
+      } catch {
+        expect.toBeTruthy(true); // 目录不存在,符合预期
+      }
+
+      // 验证archived目录中有归档文件
+      const archivedEntries = await fs.readdir(testArchivedDir);
+      expect.toEqual(archivedEntries.length, 1);
+      expect.toBeTruthy(archivedEntries[0].match(/^to-archive-[a-f0-9]{8}$/));
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('6. archiveSkill - 技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.archiveSkill('nonexistent');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('7. unarchiveSkill - 成功恢复归档技能', async () => {
+    await setupTestEnv();
+    try {
+      // 创建归档技能
+      const archivedDir = path.join(testArchivedDir, 'original-name-a1b2c3d4');
+      await fs.mkdir(archivedDir, { recursive: true });
+      await fs.writeFile(path.join(archivedDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 恢复
+      await manager.unarchiveSkill('original-name-a1b2c3d4');
+
+      // 验证归档目录不存在
+      try {
+        await fs.access(archivedDir);
+        expect.toBeTruthy(false); // 不应该执行到这里
+      } catch {
+        expect.toBeTruthy(true); // 目录不存在,符合预期
+      }
+
+      // 验证技能目录存在
+      const skillDir = path.join(testSkillsDir, 'original-name');
+      await fs.access(skillDir);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('7. unarchiveSkill - 归档技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.unarchiveSkill('nonexistent-a1b2c3d4');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '归档技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('7. unarchiveSkill - 目标名称已存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      // 创建在线技能
+      const skillDir = path.join(testSkillsDir, 'conflict');
+      await fs.mkdir(skillDir, { recursive: true });
+
+      // 创建归档技能
+      const archivedDir = path.join(testArchivedDir, 'conflict-a1b2c3d4');
+      await fs.mkdir(archivedDir, { recursive: true });
+      await fs.writeFile(path.join(archivedDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      let hasError = false;
+      try {
+        await manager.unarchiveSkill('conflict-a1b2c3d4');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能已存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('8. exportSkill - 成功导出在线技能', async () => {
+    await setupTestEnv();
+    try {
+      // 创建技能
+      const skillDir = path.join(testSkillsDir, 'to-export');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 导出
+      const zipPath = await manager.exportSkill('to-export', false);
+
+      // 验证zip文件路径
+      expect.toBeTruthy(zipPath.match(/[/\\]to-export\.zip$/));
+      await fs.access(zipPath);
+
+      // 清理
+      await fs.rm(zipPath, { force: true });
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('8. exportSkill - 成功导出归档技能', async () => {
+    await setupTestEnv();
+    try {
+      // 创建归档技能
+      const archivedDir = path.join(testArchivedDir, 'archived-skill-a1b2c3d4');
+      await fs.mkdir(archivedDir, { recursive: true });
+      await fs.writeFile(path.join(archivedDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 导出
+      const zipPath = await manager.exportSkill('archived-skill-a1b2c3d4', true);
+
+      // 验证zip文件路径
+      expect.toBeTruthy(zipPath.match(/[/\\]archived-skill-a1b2c3d4\.zip$/));
+      await fs.access(zipPath);
+
+      // 清理
+      await fs.rm(zipPath, { force: true });
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('8. exportSkill - 技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.exportSkill('nonexistent', false);
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('9. getOnlineSkillContent - 成功获取在线技能内容', async () => {
+    await setupTestEnv();
+    try {
+      // 创建技能
+      const skillDir = path.join(testSkillsDir, 'test-skill');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 获取内容
+      const content = await manager.getOnlineSkillContent('test-skill');
+
+      expect.toEqual(content, validSkillMd);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('9. getOnlineSkillContent - 技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.getOnlineSkillContent('nonexistent');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('10. getArchivedSkillContent - 成功获取归档技能内容', async () => {
+    await setupTestEnv();
+    try {
+      // 创建归档技能
+      const archivedDir = path.join(testArchivedDir, 'test-skill-a1b2c3d4');
+      await fs.mkdir(archivedDir, { recursive: true });
+      await fs.writeFile(path.join(archivedDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      // 获取内容
+      const content = await manager.getArchivedSkillContent('test-skill-a1b2c3d4');
+
+      expect.toEqual(content, validSkillMd);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('10. getArchivedSkillContent - 归档技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.getArchivedSkillContent('nonexistent-a1b2c3d4');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '归档技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('11. getOnlineSkillStructure - 成功获取在线技能目录结构', async () => {
+    await setupTestEnv();
+    try {
+      // 创建技能及其子目录
+      const skillDir = path.join(testSkillsDir, 'test-skill');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      const scriptsDir = path.join(skillDir, 'scripts');
+      await fs.mkdir(scriptsDir, { recursive: true });
+      await fs.writeFile(path.join(scriptsDir, 'test.sh'), 'echo test', 'utf-8');
+
+      // 获取目录结构
+      const structure = await manager.getOnlineSkillStructure('test-skill');
+
+      expect.toEqual((structure as any).name, 'test-skill');
+      expect.toEqual((structure as any).type, 'directory');
+      expect.toBeTruthy((structure as any).children);
+      expect.toBeTruthy((structure as any).children.length >= 2); // SKILL.md and scripts/
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('11. getOnlineSkillStructure - 技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.getOnlineSkillStructure('nonexistent');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('12. getArchivedSkillStructure - 成功获取归档技能目录结构', async () => {
+    await setupTestEnv();
+    try {
+      // 创建归档技能及其子目录
+      const archivedDir = path.join(testArchivedDir, 'test-skill-a1b2c3d4');
+      await fs.mkdir(archivedDir, { recursive: true });
+      await fs.writeFile(path.join(archivedDir, 'SKILL.md'), validSkillMd, 'utf-8');
+
+      const scriptsDir = path.join(archivedDir, 'scripts');
+      await fs.mkdir(scriptsDir, { recursive: true });
+      await fs.writeFile(path.join(scriptsDir, 'test.sh'), 'echo test', 'utf-8');
+
+      // 获取目录结构
+      const structure = await manager.getArchivedSkillStructure('test-skill-a1b2c3d4');
+
+      expect.toEqual((structure as any).name, 'test-skill-a1b2c3d4');
+      expect.toEqual((structure as any).type, 'directory');
+      expect.toBeTruthy((structure as any).children);
+      expect.toBeTruthy((structure as any).children.length >= 2); // SKILL.md and scripts/
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('12. getArchivedSkillStructure - 归档技能不存在时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.getArchivedSkillStructure('nonexistent-a1b2c3d4');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '归档技能不存在');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('2. installSkill - 空来源时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.installSkill('');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能来源不能为空');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  })
+  .test('2. installSkill - 只包含空格时抛出错误', async () => {
+    await setupTestEnv();
+    try {
+      let hasError = false;
+      try {
+        await manager.installSkill('   ');
+      } catch (error: any) {
+        hasError = true;
+        expect.toContain(error.message, '技能来源不能为空');
+      }
+      expect.toBeTruthy(hasError);
+    } finally {
+      await cleanupTestEnv();
+    }
+  });
+
+export async function run() {
+  return await runner.run();
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/tests/skills/stage1-verification.ts
+++ b/tests/skills/stage1-verification.ts
@@ -1,0 +1,143 @@
+/**
+ * 阶段一开发验证脚本
+ *
+ * 验证 SkillsManagementManager 的所有核心功能
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { SkillsManagementManager } from '../../src/core/skills/management-manager';
+
+async function verifyStage1() {
+  console.log('='.repeat(80));
+  console.log('阶段一开发验证 - SkillsManagementManager');
+  console.log('='.repeat(80));
+  console.log();
+
+  // 创建测试环境
+  const testDir = path.join(os.tmpdir(), `stage1-verify-${Date.now()}`);
+  const skillsDir = path.join(testDir, '.skills');
+  const archivedDir = path.join(skillsDir, '.archived');
+
+  await fs.mkdir(skillsDir, { recursive: true });
+  await fs.mkdir(archivedDir, { recursive: true });
+
+  const manager = new SkillsManagementManager(skillsDir, archivedDir);
+
+  try {
+    // 1. 验证基本功能
+    console.log('✓ SkillsManagementManager 实例化成功');
+
+    // 2. 创建测试技能
+    const testSkillDir = path.join(skillsDir, 'test-skill');
+    await fs.mkdir(testSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(testSkillDir, 'SKILL.md'),
+      `---
+name: test-skill
+description: A test skill for stage 1 verification
+---
+
+# Test Skill
+
+This is a test skill for verifying stage 1 implementation.`,
+      'utf-8'
+    );
+    console.log('✓ 测试技能创建成功');
+
+    // 3. 测试列出在线技能
+    const skills = await manager.listSkills();
+    console.log(`✓ listSkills: 找到 ${skills.length} 个在线技能`);
+    if (skills.length > 0) {
+      console.log(`  - ${skills[0].name}: ${skills[0].description}`);
+    }
+
+    // 4. 测试复制技能
+    const newSkillName = await manager.copySkill('test-skill');
+    console.log(`✓ copySkill: 复制技能成功 -> ${newSkillName}`);
+
+    // 5. 测试重命名技能
+    await manager.renameSkill(newSkillName, 'renamed-skill');
+    console.log('✓ renameSkill: 重命名技能成功 -> renamed-skill');
+
+    // 6. 测试查看在线技能内容
+    const content = await manager.getOnlineSkillContent('test-skill');
+    console.log(`✓ getOnlineSkillContent: 读取内容成功 (${content.length} 字符)`);
+
+    // 7. 测试查看在线技能结构
+    const structure = await manager.getOnlineSkillStructure('test-skill');
+    console.log('✓ getOnlineSkillStructure: 获取目录结构成功');
+
+    // 8. 测试归档技能
+    await manager.archiveSkill('renamed-skill');
+    console.log('✓ archiveSkill: 归档技能成功');
+
+    // 9. 测试列出归档技能
+    const archivedSkills = await manager.listArchivedSkills();
+    console.log(`✓ listArchivedSkills: 找到 ${archivedSkills.length} 个归档技能`);
+    if (archivedSkills.length > 0) {
+      console.log(`  - ${archivedSkills[0].originalName} -> ${archivedSkills[0].archivedName}`);
+    }
+
+    // 10. 测试查看归档技能内容
+    const archivedContent = await manager.getArchivedSkillContent(archivedSkills[0].archivedName);
+    console.log(`✓ getArchivedSkillContent: 读取归档内容成功 (${archivedContent.length} 字符)`);
+
+    // 11. 测试查看归档技能结构
+    const archivedStructure = await manager.getArchivedSkillStructure(archivedSkills[0].archivedName);
+    console.log('✓ getArchivedSkillStructure: 获取归档目录结构成功');
+
+    // 12. 测试恢复归档技能
+    await manager.unarchiveSkill(archivedSkills[0].archivedName);
+    console.log('✓ unarchiveSkill: 恢复归档技能成功');
+
+    // 13. 测试导出技能
+    const exportPath = await manager.exportSkill('test-skill', false);
+    console.log(`✓ exportSkill: 导出技能成功 -> ${exportPath}`);
+    await fs.rm(exportPath, { force: true });
+
+    // 14. 验证 installSkill 参数验证
+    let hasError = false;
+    try {
+      await manager.installSkill('');
+    } catch (error: any) {
+      hasError = true;
+    }
+    if (hasError) {
+      console.log('✓ installSkill: 参数验证正常（空字符串抛出错误）');
+    }
+
+    console.log();
+    console.log('='.repeat(80));
+    console.log('阶段一验证完成！所有核心功能正常工作。');
+    console.log('='.repeat(80));
+    console.log();
+    console.log('已实现的功能:');
+    console.log('  1. ✓ listSkills - 列出在线技能');
+    console.log('  2. ✓ installSkill - 安装新技能');
+    console.log('  3. ✓ listArchivedSkills - 列出归档技能');
+    console.log('  4. ✓ importSkill - 导入技能（zip）');
+    console.log('  5. ✓ copySkill - 复制技能');
+    console.log('  6. ✓ renameSkill - 重命名技能');
+    console.log('  7. ✓ archiveSkill - 归档技能');
+    console.log('  8. ✓ unarchiveSkill - 恢复归档技能');
+    console.log('  9. ✓ getOnlineSkillContent - 查看在线技能内容');
+    console.log(' 10. ✓ getArchivedSkillContent - 查看归档技能内容');
+    console.log(' 11. ✓ getOnlineSkillStructure - 查看在线技能目录结构');
+    console.log(' 12. ✓ getArchivedSkillStructure - 查看归档技能目录结构');
+    console.log(' 13. ✓ exportSkill - 导出技能');
+    console.log();
+  } catch (error: any) {
+    console.error('✗ 验证失败:', error.message);
+    process.exit(1);
+  } finally {
+    // 清理测试环境
+    await fs.rm(testDir, { recursive: true, force: true });
+  }
+}
+
+verifyStage1().catch((err) => {
+  console.error('验证脚本错误:', err);
+  process.exit(1);
+});

--- a/tests/skills/test-management-manager.ts
+++ b/tests/skills/test-management-manager.ts
@@ -1,0 +1,143 @@
+/**
+ * SkillsManagementManager 功能验证脚本
+ *
+ * 手动运行: ts-node --project tsconfig.json ./tests/skills/test-management-manager.ts
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { SkillsManagementManager } from '../../src/core/skills/management-manager';
+
+async function testManagementManager() {
+  console.log('\n========================================');
+  console.log('SkillsManagementManager 功能验证');
+  console.log('========================================\n');
+
+  // 创建临时测试目录
+  const testSkillsDir = path.join(os.tmpdir(), `test-skills-${Date.now()}`);
+  const testArchivedDir = path.join(testSkillsDir, '.archived');
+
+  await fs.mkdir(testSkillsDir, { recursive: true });
+  await fs.mkdir(testArchivedDir, { recursive: true });
+
+  const manager = new SkillsManagementManager(testSkillsDir, testArchivedDir);
+
+  try {
+    // 测试数据
+    const validSkillMd = `---
+name: test-skill
+description: A test skill for validation
+---
+
+# Test Skill
+
+This is a test skill for validating the SkillsManagementManager.`;
+
+    // ========== 测试1: 列出在线技能(空列表) ==========
+    console.log('✓ 测试1: listSkills() - 空列表');
+    let skills = await manager.listSkills();
+    console.assert(skills.length === 0, '  应返回空列表');
+    console.log('  通过: 返回空列表\n');
+
+    // ========== 测试2: 创建测试技能 ==========
+    console.log('✓ 测试2: 创建测试技能');
+    const skillDir = path.join(testSkillsDir, 'test-skill');
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, 'SKILL.md'), validSkillMd, 'utf-8');
+    console.log('  通过: 创建test-skill\n');
+
+    // ========== 测试3: 列出在线技能 ==========
+    console.log('✓ 测试3: listSkills() - 列出技能');
+    skills = await manager.listSkills();
+    console.assert(skills.length === 1, '  应返回1个技能');
+    console.assert(skills[0].name === 'test-skill', '  名称应为test-skill');
+    console.log(`  通过: 列出 ${skills.length} 个技能 - ${skills[0].name}\n`);
+
+    // ========== 测试4: 复制技能 ==========
+    console.log('✓ 测试4: copySkill() - 复制技能');
+    const newSkillName = await manager.copySkill('test-skill');
+    console.assert(newSkillName.match(/^test-skill-[a-f0-9]{8}$/), '  应生成8位后缀');
+    console.log(`  通过: 复制为 ${newSkillName}\n`);
+
+    // ========== 测试5: 重命名技能 ==========
+    console.log('✓ 测试5: renameSkill() - 重命名技能');
+    await manager.renameSkill('test-skill', 'renamed-skill');
+    const renamedExists = await fs.access(path.join(testSkillsDir, 'renamed-skill')).then(() => true).catch(() => false);
+    console.assert(renamedExists, '  重命名后目录应存在');
+    console.log('  通过: test-skill -> renamed-skill\n');
+
+    // ========== 测试6: 归档技能 ==========
+    console.log('✓ 测试6: archiveSkill() - 归档技能');
+    await manager.archiveSkill('renamed-skill');
+    const archivedSkills = await manager.listArchivedSkills();
+    console.assert(archivedSkills.length === 1, '  应有1个归档技能');
+    console.assert(archivedSkills[0].originalName === 'renamed-skill', '  原始名称应为renamed-skill');
+    console.log(`  通过: 归档为 ${archivedSkills[0].archivedName}\n`);
+
+    // ========== 测试7: 恢复归档技能 ==========
+    console.log('✓ 测试7: unarchiveSkill() - 恢复归档技能');
+    await manager.unarchiveSkill(archivedSkills[0].archivedName);
+    skills = await manager.listSkills();
+    console.assert(skills.length === 2, '  应有2个在线技能');
+    console.log('  通过: 恢复归档技能\n');
+
+    // ========== 测试8: 导出技能 ==========
+    console.log('✓ 测试8: exportSkill() - 导出技能');
+    const zipPath = await manager.exportSkill('renamed-skill', false);
+    console.assert(zipPath.endsWith('.zip'), '  应生成zip文件');
+    const zipExists = await fs.access(zipPath).then(() => true).catch(() => false);
+    console.assert(zipExists, '  zip文件应存在');
+    console.log(`  通过: 导出为 ${zipPath}\n`);
+
+    // ========== 测试9: SKILL.md验证 ==========
+    console.log('✓ 测试9: validateSkillMd() - 验证SKILL.md格式');
+    const invalidDir = path.join(testSkillsDir, 'invalid-skill');
+    await fs.mkdir(invalidDir, { recursive: true });
+    await fs.writeFile(
+      path.join(invalidDir, 'SKILL.md'),
+      '---\nname: INVALID-Name\n---\n',
+      'utf-8'
+    );
+    skills = await manager.listSkills();
+    console.assert(skills.length === 2, '  无效技能应被跳过');
+    console.log('  通过: 无效技能被过滤\n');
+
+    // ========== 总结 ==========
+    console.log('========================================');
+    console.log('✅ 所有功能验证通过!');
+    console.log('========================================\n');
+
+    console.log('已实现的8个核心方法:');
+    console.log('  1. listSkills()       - 列出在线技能');
+    console.log('  2. listArchivedSkills() - 列出归档技能');
+    console.log('  3. importSkill()     - 导入技能(zip)');
+    console.log('  4. copySkill()       - 复制技能(8位随机后缀)');
+    console.log('  5. renameSkill()     - 重命名技能');
+    console.log('  6. archiveSkill()    - 归档技能(8位随机后缀)');
+    console.log('  7. unarchiveSkill()  - 恢复归档技能');
+    console.log('  8. exportSkill()     - 导出技能(zip)');
+    console.log('');
+
+    console.log('符合文档规范的关键特性:');
+    console.log('  ✓ 归档命名格式: {skillName}-{XXXXXXXX} (8位随机后缀)');
+    console.log('  ✓ SKILL.md格式验证(遵循Specification.md)');
+    console.log('  ✓ 与SkillsManager完全独立(路径1 vs 路径2)');
+    console.log('  ✓ 删除了文档外的额外方法\n');
+
+  } catch (error: any) {
+    console.error('\n❌ 测试失败:', error.message);
+    console.error(error.stack);
+    process.exitCode = 1;
+  } finally {
+    // 清理测试目录
+    await fs.rm(testSkillsDir, { recursive: true, force: true });
+    console.log('清理: 测试目录已删除\n');
+  }
+}
+
+// 运行测试
+testManagementManager().catch(err => {
+  console.error('测试运行器错误:', err);
+  process.exitCode = 1;
+});

--- a/tests/unit/core/skills-folder-name.test.ts
+++ b/tests/unit/core/skills-folder-name.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Skills Manager 文件夹名称测试
+ *
+ * 测试SkillsManager使用文件夹名称作为技能标识符
+ */
+
+import { TestRunner, expect } from '../../helpers/utils';
+import { SkillsManager } from '../../../src/core/skills/manager';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const runner = new TestRunner('SkillsManager - 文件夹名称作为标识符');
+
+async function createTestSkill(baseDir: string, folderName: string, yamlName: string, description: string) {
+  const skillDir = path.join(baseDir, folderName);
+  await fs.mkdir(skillDir, { recursive: true });
+
+  const skillContent = `---
+name: ${yamlName}
+description: ${description}
+---
+
+# Test Skill
+
+This skill tests folder name as identifier.
+`;
+  await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillContent);
+  return skillDir;
+}
+
+runner
+  .test('应该使用文件夹名称作为技能标识符，而非YAML中的name字段', async () => {
+    // 创建临时测试目录
+    const testDir = path.join(process.cwd(), 'test-skills-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      // 创建测试skill：文件夹名称与YAML中的name不同
+      await createTestSkill(testDir, 'folder-name-skill', 'yaml-name-skill', 'Test skill with different folder name');
+
+      // 扫描skills
+      const skills = await manager.getSkillsMetadata();
+
+      expect.toEqual(skills.length, 1);
+      // 关键验证：使用文件夹名称，而非YAML中的name
+      expect.toEqual(skills[0].name, 'folder-name-skill');
+      // 验证不等于YAML中的name
+      if (skills[0].name === 'yaml-name-skill') {
+        throw new Error('Expected folder name, not YAML name');
+      }
+      expect.toEqual(skills[0].description, 'Test skill with different folder name');
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  })
+
+  .test('应该在列表中显示文件夹名称', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      // 创建多个skill
+      await createTestSkill(testDir, 'skill-a', 'different-name-a', 'Skill A');
+      await createTestSkill(testDir, 'skill-b', 'different-name-b', 'Skill B');
+
+      // 扫描skills
+      const skills = await manager.getSkillsMetadata();
+
+      expect.toEqual(skills.length, 2);
+      // 验证返回的名称是文件夹名称
+      const skillNames = skills.map(s => s.name).sort();
+      expect.toEqual(skillNames[0], 'skill-a');
+      expect.toEqual(skillNames[1], 'skill-b');
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  })
+
+  .test('应该使用文件夹名称加载技能内容', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      // 创建测试skill
+      await createTestSkill(testDir, 'load-test-skill', 'yaml-load-name', 'Test loading with folder name');
+
+      // 使用文件夹名称加载
+      const content = await manager.loadSkillContent('load-test-skill');
+
+      expect.toBeTruthy(content);
+      expect.toEqual(content!.metadata.name, 'load-test-skill');
+      // 验证不等于YAML中的name
+      if (content!.metadata.name === 'yaml-load-name') {
+        throw new Error('Expected folder name, not YAML name');
+      }
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  })
+
+  .test('应该返回null当使用YAML中的name加载（非文件夹名）', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      // 创建测试skill
+      await createTestSkill(testDir, 'correct-folder-name', 'wrong-yaml-name', 'Test skill');
+
+      // 使用YAML中的name（错误的方式）应该返回null
+      const content1 = await manager.loadSkillContent('wrong-yaml-name');
+      expect.toEqual(content1, null);
+
+      // 使用文件夹名称（正确的方式）应该成功
+      const content2 = await manager.loadSkillContent('correct-folder-name');
+      expect.toBeTruthy(content2);
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  })
+
+  .test('白名单应该匹配文件夹名称', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+
+    try {
+      // 创建两个skill
+      await createTestSkill(testDir, 'allowed-skill', 'yaml-allowed', 'Allowed skill');
+      await createTestSkill(testDir, 'blocked-skill', 'yaml-blocked', 'Blocked skill');
+
+      // 创建只允许 'allowed-skill' 的manager
+      const managerWithWhitelist = new SkillsManager(testDir, ['allowed-skill']);
+      const skills = await managerWithWhitelist.getSkillsMetadata();
+
+      expect.toEqual(skills.length, 1);
+      expect.toEqual(skills[0].name, 'allowed-skill');
+
+      // 验证可以加载白名单中的skill
+      const content = await managerWithWhitelist.loadSkillContent('allowed-skill');
+      expect.toBeTruthy(content);
+
+      // 验证不能加载非白名单中的skill
+      const blockedContent = await managerWithWhitelist.loadSkillContent('blocked-skill');
+      expect.toEqual(blockedContent, null);
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+export async function run() {
+  return await runner.run();
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/tests/unit/core/skills-full-content-test.ts
+++ b/tests/unit/core/skills-full-content-test.ts
@@ -1,0 +1,194 @@
+/**
+ * Skills 完整内容加载测试
+ *
+ * 验证 loadSkillContent 正确加载完整的 SKILL.md 内容
+ * 包括 YAML frontmatter（name、description 等）和正文
+ */
+
+import { TestRunner, expect } from '../../helpers/utils';
+import { SkillsManager } from '../../../src/core/skills/manager';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const runner = new TestRunner('Skills - 完整内容加载验证');
+
+async function createTestSkill(baseDir: string, folderName: string, yamlName: string, description: string) {
+  const skillDir = path.join(baseDir, folderName);
+  await fs.mkdir(skillDir, { recursive: true });
+
+  const skillContent = `---
+name: ${yamlName}
+description: ${description}
+license: Apache-2.0
+metadata:
+  author: test-author
+  version: "1.0"
+---
+
+# ${yamlName}
+
+This is the complete skill instruction for ${yamlName}.
+
+## Features
+
+- Feature 1
+- Feature 2
+
+## Usage
+
+Use this skill when you need to ${description.toLowerCase()}.
+`;
+  await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillContent);
+  return skillDir;
+}
+
+runner
+  .test('应该加载完整的SKILL.md内容，包括YAML frontmatter和正文', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-full-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      await createTestSkill(testDir, 'test-skill', 'yaml-test-name', 'Test description for full content');
+
+      // 加载技能内容
+      const content = await manager.loadSkillContent('test-skill');
+
+      expect.toBeTruthy(content);
+      expect.toBeTruthy(content!.content);
+
+      // 验证完整的 SKILL.md 内容
+      const fullContent = content!.content;
+
+      // 1. 验证包含 YAML frontmatter 的开始标记
+      expect.toContain(fullContent, '---');
+
+      // 2. 验证包含 YAML 中的 name 字段
+      expect.toContain(fullContent, 'name: yaml-test-name');
+
+      // 3. 验证包含 YAML 中的 description 字段
+      expect.toContain(fullContent, 'description: Test description for full content');
+
+      // 4. 验证包含 YAML 中的 license 字段
+      expect.toContain(fullContent, 'license: Apache-2.0');
+
+      // 5. 验证包含 YAML 中的 metadata 字段
+      expect.toContain(fullContent, 'metadata:');
+      expect.toContain(fullContent, 'author: test-author');
+      expect.toContain(fullContent, 'version: "1.0"');
+
+      // 6. 验证包含 YAML frontmatter 的结束标记
+      expect.toContain(fullContent, '---\n');
+
+      // 7. 验证包含正文标题
+      expect.toContain(fullContent, '# yaml-test-name');
+
+      // 8. 验证包含正文内容
+      expect.toContain(fullContent, 'This is the complete skill instruction');
+      expect.toContain(fullContent, '## Features');
+      expect.toContain(fullContent, '- Feature 1');
+      expect.toContain(fullContent, '- Feature 2');
+      expect.toContain(fullContent, '## Usage');
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  })
+
+  .test('返回的metadata应该包含文件夹名称和description', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-meta-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      await createTestSkill(testDir, 'folder-skill', 'yaml-skill-name', 'Meta description test');
+
+      const content = await manager.loadSkillContent('folder-skill');
+
+      expect.toBeTruthy(content);
+      expect.toBeTruthy(content!.metadata);
+
+      // metadata.name 应该是文件夹名称
+      expect.toEqual(content!.metadata.name, 'folder-skill');
+
+      // metadata.description 应该从 YAML 中提取
+      expect.toEqual(content!.metadata.description, 'Meta description test');
+
+      // metadata.path 应该指向 SKILL.md
+      expect.toContain(content!.metadata.path, 'SKILL.md');
+
+      // metadata.baseDir 应该是文件夹路径
+      expect.toContain(content!.metadata.baseDir, 'folder-skill');
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  })
+
+  .test('content字段应该包含完整的原始SKILL.md内容（未解析）', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-raw-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      const yamlName = 'raw-content-skill';
+      await createTestSkill(testDir, 'raw-skill', yamlName, 'Raw content verification');
+
+      const content = await manager.loadSkillContent('raw-skill');
+
+      expect.toBeTruthy(content);
+
+      // 读取原始文件进行对比
+      const originalContent = await fs.readFile(content!.metadata.path, 'utf-8');
+
+      // content 字段应该与原始文件完全一致
+      expect.toEqual(content!.content, originalContent);
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  })
+
+  .test('工具返回的数据应该包含完整的content字段', async () => {
+    const testDir = path.join(process.cwd(), 'test-skills-tool-' + Date.now());
+    await fs.mkdir(testDir, { recursive: true });
+    const manager = new SkillsManager(testDir);
+
+    try {
+      await createTestSkill(testDir, 'tool-test-skill', 'tool-yaml-name', 'Tool content test');
+
+      const content = await manager.loadSkillContent('tool-test-skill');
+
+      // 验证返回的数据结构
+      expect.toBeTruthy(content);
+      expect.toBeTruthy(content!.metadata);
+      expect.toBeTruthy(content!.content);
+
+      // 验证 content 字段包含完整信息
+      const skillContent = content!.content;
+
+      // 应该包含 YAML 中的 name（不是文件夹名）
+      expect.toContain(skillContent, 'name: tool-yaml-name');
+
+      // 应该包含 YAML 中的 description
+      expect.toContain(skillContent, 'description: Tool content test');
+
+      // 应该包含完整的元数据
+      expect.toContain(skillContent, 'license: Apache-2.0');
+      expect.toContain(skillContent, 'author: test-author');
+
+      // 应该包含正文
+      expect.toContain(skillContent, '# tool-yaml-name');
+      expect.toContain(skillContent, 'This is the complete skill instruction');
+    } finally {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+export async function run() {
+  return await runner.run();
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
SkillsManagementManager完全重构，简化为13个核心管理操作，移除操作队列和沙箱依赖。 默认Skills目录从 skills/ 更改为 .skills/。
归档技能命名格式从时间戳改为8位随机后缀。
技能标识符改为使用文件夹名称而非YAML中的name字段。
新增特殊白名单配置支持完全禁用或加载所有技能。
添加完整的单元测试和集成测试覆盖。

BREAKING CHANGE: SkillsManagementManager API完全变更，默认Skills目录已从 skills/ 更改为 .skills/，技能标识符改为文件夹名称，归档技能命名格式已更改