### PR TITLE
fix(core): call createAsync() for E2B sandbox initialization in Agent.create/resume

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -355,7 +355,7 @@ export class Agent {
 
     const sandbox = typeof config.sandbox === 'object' && 'exec' in config.sandbox
       ? (config.sandbox as Sandbox)
-      : deps.sandboxFactory.create(sandboxConfig || { kind: 'local', workDir: process.cwd() });
+      : await deps.sandboxFactory.createAsync(sandboxConfig || { kind: 'local', workDir: process.cwd() });
 
     const model = config.model
       ? config.model
@@ -747,7 +747,7 @@ export class Agent {
 
     let sandbox: Sandbox;
     try {
-      sandbox = deps.sandboxFactory.create(metadata.sandboxConfig || { kind: 'local', workDir: process.cwd() });
+      sandbox = await deps.sandboxFactory.createAsync(metadata.sandboxConfig || { kind: 'local', workDir: process.cwd() });
     } catch (error: any) {
       throw new ResumeError('SANDBOX_INIT_FAILED', error?.message || 'Failed to create sandbox');
     }


### PR DESCRIPTION
## 概述
  修复 E2B 沙箱在 `Agent.create()` 和 `Agent.resume()` 中未初始化的问题

  ## 问题描述
  使用 E2B 沙箱时，`Agent.create()` 和 `Agent.resume()` 调用的是同步方法 `SandboxFactory.create()`，导致 E2B 沙箱的 `init()` 方法从未被调用，沙箱处于未初始化状态。

  ## 修复方案
  将两处 `sandboxFactory.create()` 改为 `await sandboxFactory.createAsync()`：
  - `agent.ts:358` (Agent.create)
  - `agent.ts:750` (Agent.resume)

  `createAsync()` 会检测 E2B 沙箱并调用其 `init()` 方法完成初始化。

  ## 测试验证
  - [x] 228 个单元测试全部通过
  - [x] 对 Local 沙箱无影响（无需 init）