### PR TITLE
fix: JSONStore.exists() validates meta.json integrity and add Agent.r…

### DIFF
--- a/src/infra/store/json-store.ts
+++ b/src/infra/store/json-store.ts
@@ -673,7 +673,8 @@ export class JSONStore implements Store {
     const fs = require('fs').promises;
     try {
       await fs.access(this.getAgentDir(agentId));
-      return true;
+      const info = await this.loadInfo(agentId);
+      return !!(info && info.metadata);
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary

修复 `JSONStore.exists()` 与 `Agent.resumeFromStore()` 的语义不一致。增强 `exists()` 使其验证 `meta.json` 完整性，并新增 `Agent.resumeOrCreate()` 提供安全的恢复回退机制。

## Motivation / Context

`JSONStore.exists()` 仅通过 `fs.access` 检查目录是否存在，不验证 `meta.json`。导致目录存在但数据损坏时 `exists()` 返回 `true`，而 `resumeFromStore()` 抛出 `ResumeError`。集成方必须自行编写 try-catch + 清理逻辑。SQLite/Postgres Store 基于数据库查询，不存在此问题。相关 issue: #4

## Type of Change
- [x] 缺陷修复
- [x] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 测试
- [ ] 构建/杂项

## Scope / Modules
- [x] core (agent / events / pool / room / scheduler)
- [x] infra (db / provider / sandbox / store)
- [ ] tools (fs / bash / mcp / skills / task)
- [ ] skills
- [ ] examples
- [ ] docs (en / zh-CN)
- [x] tests
- [ ] other: ___

## Public API
- [ ] `src/index.ts` 导出有变更
- [x] 无公开 API 变更

## Breaking Changes
- [ ] 有，附报告（含必要性说明）及过渡方案
- [x] 无

## Testing
- [x] `npm run test:unit`（必需）
- [ ] `npm run test:integration`（按需）
- [ ] `npm run test:e2e`（按需）

## Impact / Risk

- `JSONStore.exists()` 对目录存在但 `meta.json` 缺失/损坏的情况现在返回 `false`，与 SQLite/Postgres Store 语义对齐。依赖旧行为（仅检查目录）的代码可能受影响。
- `Agent.resumeOrCreate()` 是新增方法，不影响现有代码。

## Checklist
- [x] 新功能包含相关测试
- [x] 测试遵循 `tests/README.md` 规范
- [x] 未提交密钥或令牌
- [x] 无 `dist/` 变更
- [x] 仅更新对应包管理器的 lockfile
