### PR TITLE
fix(openai): preserve non-v1 version suffix in base URL

### DIFF
--- a/src/infra/providers/utils.ts
+++ b/src/infra/providers/utils.ts
@@ -58,8 +58,8 @@ export function normalizeBaseUrl(url: string): string {
 
 export function normalizeOpenAIBaseUrl(url: string): string {
   let normalized = url.replace(/\/+$/, '');
-  // Auto-append /v1 if not present (for OpenAI-compatible APIs)
-  if (!normalized.endsWith('/v1')) {
+  // Auto-append /v1 if no version path detected (e.g., /v1, /v2, /v4)
+  if (!/\/v\d+$/.test(normalized)) {
     normalized += '/v1';
   }
   return normalized;

--- a/tests/unit/providers/openai.test.ts
+++ b/tests/unit/providers/openai.test.ts
@@ -10,6 +10,11 @@ runner
     const config = provider.toConfig();
     expect.toEqual(config.baseUrl, 'https://api.openai.com/v1');
   })
+  .test('baseUrl 保留已有版本路径 /v4 (GLM coding endpoint)', async () => {
+    const provider = new OpenAIProvider('test-key', 'any-model', 'https://open.bigmodel.cn/api/coding/paas/v4');
+    const config = provider.toConfig();
+    expect.toEqual(config.baseUrl, 'https://open.bigmodel.cn/api/coding/paas/v4');
+  })
   .test('请求体包含 system 与工具调用结构', async () => {
     const provider = new OpenAIProvider('test-key', 'gpt-4o', 'https://api.openai.com');
     const messages: Message[] = [


### PR DESCRIPTION
## Summary

  修复 OpenAI 兼容基座 URL 归一化逻辑：当 baseUrl 已包含版本后缀（如 /v2、/v4）时不再错误追加 /v1。
  新增回归测试，确保 GLM 等 /v4 端点路径被原样保留。

  ## Motivation / Context

  在 OpenAI 兼容提供方（如 GLM）中，常见基座为 .../v4。旧逻辑会将其归一化为 .../v4/v1，导致请求路径错误
  （404）或返回异常，进而出现上层空响应等问题。
  该问题影响真实线上接入稳定性，需要在 SDK 侧修正并通过测试固化。

  ## Type of Change

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [x] Test
  - [ ] Chore / Build

  ## Scope / Modules

  - [ ] core (agent / events / pool / room / scheduler)
  - [x] infra (db / provider / sandbox / store)
  - [ ] tools (fs / bash / mcp / skills / task)
  - [ ] skills
  - [ ] examples
  - [ ] docs (en / zh-CN)
  - [x] tests
  - [ ] other: ___

  ## Public API

  - [x] No public API change
  - [ ] Exports changed in src/index.ts

  ## Breaking Changes

  - [ ] Yes , and attach report(include necessity) and transition plan
  - [x] No

  ## Testing

  - [ ] npm run test:unit(required)
  - [ ] npm run test:integration(if needed)
  - [ ] npm run test:e2e(if needed)

  补充说明：已执行并通过 tests/unit/providers/openai.test.ts（包含新增回归用例）。当前环境下未完整跑全
  量 npm run test:unit。

  ## Impact / Risk

  影响面主要在 OpenAI Provider 的 baseUrl 归一化：

  - 正向：修复 /v4、/v2 等已带版本路径的兼容接口调用。
  - 风险：低。未改变无版本路径场景（仍会自动补 /v1），并新增测试覆盖该行为。

  ## Checklist

  - [ ] Docs updated if needed
  - [ ] Examples updated if needed
  - [x] New feature includes related tests and docs
  - [x] Tests follow tests/README.md structure
  - [ ] Docs follow docs/en + docs/zh-CN format rules
  - [x] No secrets or tokens committed
  - [x] No dist/ changes (unless release)
  - [x] Only one lockfile updated for the package manager used