### PR TITLE
fix(gemini): emit reasoning chunks and fix thought parts extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,15 +51,13 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmmirror.com/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.0.0-rc.3",
       "resolved": "https://registry.npmmirror.com/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
       "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -268,7 +266,6 @@
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -922,7 +919,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1675,7 +1671,6 @@
       "resolved": "https://registry.npmmirror.com/pg/-/pg-8.17.2.tgz",
       "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.1",
         "pg-pool": "^3.11.0",
@@ -2542,7 +2537,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2755,7 +2749,6 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/infra/providers/gemini.ts
+++ b/src/infra/providers/gemini.ts
@@ -324,9 +324,24 @@ export class GeminiProvider implements ModelProvider {
         const parsed = JSON.parse(buffer.trim());
         const events = Array.isArray(parsed) ? parsed : [parsed];
         for (const event of events) {
-          const { textChunks, functionCalls, usage } = this.parseGeminiChunk(event);
+          const { textChunks, thoughtChunks, functionCalls, usage } = this.parseGeminiChunk(event);
           if (usage) {
             lastUsage = usage;
+          }
+          for (const text of thoughtChunks) {
+            if (!thinkStarted) {
+              thinkStarted = true;
+              yield {
+                type: 'content_block_start',
+                index: thinkIndex,
+                content_block: { type: 'reasoning', reasoning: '' },
+              };
+            }
+            yield {
+              type: 'content_block_delta',
+              index: thinkIndex,
+              delta: { type: 'reasoning_delta', text },
+            };
           }
           for (const text of textChunks) {
             if (!textStarted) {
@@ -632,7 +647,7 @@ export class GeminiProvider implements ModelProvider {
     for (const candidate of candidates) {
       const parts = candidate?.content?.parts ?? [];
       for (const part of parts) {
-        if (typeof part?.text === 'string') {
+        if (typeof part?.text === 'string' && part.text.length > 0) {
           if (part.thought === true && this.reasoningTransport === 'provider') {
             thoughtChunks.push(part.text);
           } else {

--- a/src/infra/providers/gemini.ts
+++ b/src/infra/providers/gemini.ts
@@ -412,9 +412,15 @@ export class GeminiProvider implements ModelProvider {
     if (opts.maxTokens !== undefined) generationConfig.maxOutputTokens = opts.maxTokens;
 
     if (opts.thinking?.budgetTokens) {
-      generationConfig.thinkingConfig = { thinkingBudget: opts.thinking.budgetTokens };
+      generationConfig.thinkingConfig = {
+        thinkingBudget: opts.thinking.budgetTokens,
+        includeThoughts: true,
+      };
     } else if (opts.thinking?.level) {
-      generationConfig.thinkingConfig = { thinkingLevel: opts.thinking.level.toUpperCase() };
+      generationConfig.thinkingConfig = {
+        thinkingLevel: opts.thinking.level.toUpperCase(),
+        includeThoughts: true,
+      };
     }
 
     const body: any = {

--- a/src/infra/providers/gemini.ts
+++ b/src/infra/providers/gemini.ts
@@ -231,8 +231,10 @@ export class GeminiProvider implements ModelProvider {
     const decoder = new TextDecoder();
     let buffer = '';
     let textStarted = false;
-    const textIndex = 0;
-    let toolIndex = 1;
+    let thinkStarted = false;
+    const thinkIndex = 0;
+    const textIndex = 1;
+    let toolIndex = 2;
     const toolCalls: Array<{ name: string; args: any; thoughtSignature?: string }> = [];
     let lastUsage: { input: number; output: number } | undefined;
     let collectAll = false;
@@ -274,9 +276,25 @@ export class GeminiProvider implements ModelProvider {
           break;
         }
 
-        const { textChunks, functionCalls, usage } = this.parseGeminiChunk(event);
+        const { textChunks, thoughtChunks, functionCalls, usage } = this.parseGeminiChunk(event);
         if (usage) {
           lastUsage = usage;
+        }
+
+        for (const text of thoughtChunks) {
+          if (!thinkStarted) {
+            thinkStarted = true;
+            yield {
+              type: 'content_block_start',
+              index: thinkIndex,
+              content_block: { type: 'reasoning', reasoning: '' },
+            };
+          }
+          yield {
+            type: 'content_block_delta',
+            index: thinkIndex,
+            delta: { type: 'reasoning_delta', text },
+          };
         }
 
         for (const text of textChunks) {
@@ -602,10 +620,12 @@ export class GeminiProvider implements ModelProvider {
 
   private parseGeminiChunk(event: any): {
     textChunks: string[];
+    thoughtChunks: string[];
     functionCalls: Array<{ name: string; args: any; thoughtSignature?: string }>;
     usage?: { input: number; output: number };
   } {
     const textChunks: string[] = [];
+    const thoughtChunks: string[] = [];
     const functionCalls: Array<{ name: string; args: any; thoughtSignature?: string }> = [];
 
     const candidates = Array.isArray(event?.candidates) ? event.candidates : [];
@@ -613,7 +633,11 @@ export class GeminiProvider implements ModelProvider {
       const parts = candidate?.content?.parts ?? [];
       for (const part of parts) {
         if (typeof part?.text === 'string') {
-          textChunks.push(part.text);
+          if (part.thought === true && this.reasoningTransport === 'provider') {
+            thoughtChunks.push(part.text);
+          } else {
+            textChunks.push(part.text);
+          }
         } else if (part?.functionCall) {
           const thoughtSignature = part?.thoughtSignature ?? part?.functionCall?.thoughtSignature;
           functionCalls.push({
@@ -633,6 +657,6 @@ export class GeminiProvider implements ModelProvider {
         }
       : undefined;
 
-    return { textChunks, functionCalls, usage };
+    return { textChunks, thoughtChunks, functionCalls, usage };
   }
 }

--- a/src/infra/providers/gemini.ts
+++ b/src/infra/providers/gemini.ts
@@ -574,7 +574,11 @@ export class GeminiProvider implements ModelProvider {
     const parts = content?.parts ?? [];
     for (const part of parts) {
       if (typeof part?.text === 'string') {
-        blocks.push({ type: 'text', text: part.text });
+        if (part.thought === true && this.reasoningTransport === 'provider') {
+          blocks.push({ type: 'reasoning', reasoning: part.text });
+        } else {
+          blocks.push({ type: 'text', text: part.text });
+        }
       } else if (part?.functionCall) {
         const call = part.functionCall;
         const thoughtSignature = part?.thoughtSignature ?? call?.thoughtSignature;


### PR DESCRIPTION
## Problem

When using `GeminiProvider` with thinking-capable models (e.g. `gemini-2.5-pro`), reasoning content is silently lost in three separate places:

1. **`includeThoughts` missing from request** — Gemini API requires `includeThoughts: true` in `thinkingConfig`, otherwise the model thinks internally but returns no thought parts in the response. The SDK was setting `thinkingBudget`/`thinkingLevel` without this flag.

2. **`stream()` drops thought parts** — `parseGeminiChunk` lumped all text parts into `textChunks` without distinguishing `part.thought === true`. Thought content was emitted as regular text instead of `think_chunk_*` SSE events.

3. **`collectAll` path drops thought parts** — The fallback path (when Gemini returns a JSON array instead of line-by-line SSE) had the same problem: `thoughtChunks` were never extracted, so the agent never emitted reasoning events on this path either.

A fourth issue: empty `part.text` strings (`""`) were being pushed into `textChunks`, causing spurious empty `text_chunk` SSE events.

## Changes

### `src/infra/providers/gemini.ts`

- **`_buildGenerationConfig`**: add `includeThoughts: true` whenever `thinkingBudget` or `thinkingLevel` is set.

- **`parseGeminiChunk`**: split parts by `part.thought === true` into a new `thoughtChunks: string[]` return field (only when `reasoningTransport === 'provider'`); skip empty strings.

- **`stream()` — SSE path**: consume `thoughtChunks` and yield `content_block_start(reasoning)` + `content_block_delta(reasoning_delta)` events before text chunks.

- **`stream()` — `collectAll` path**: same reasoning-chunk handling for the JSON-array fallback path.

- **`parseBlocks`** (used by `complete()`): map `part.thought === true` parts to `{ type: 'reasoning', reasoning }` blocks instead of text blocks.

## Testing

Verified end-to-end with `gemini-2.5-pro` using `reasoningTransport: 'provider'`:
- `think_chunk_start` / `think_chunk` / `think_chunk_end` SSE events now arrive correctly in streaming mode
- `complete()` returns reasoning blocks in the message content
- No regressions on non-thinking models (thought parts absent → `thoughtChunks` stays empty)